### PR TITLE
Thread Dispatcher Configurations

### DIFF
--- a/src/Dtronix.Tests/Threading/Dispatcher/QueueAsyncTests.cs
+++ b/src/Dtronix.Tests/Threading/Dispatcher/QueueAsyncTests.cs
@@ -43,7 +43,7 @@ public class QueueAsyncTests
         var task = _dispatcher.QueueAsync(async ct =>
         {
             await Task.Delay(500, ct);
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.ThrowsAsync<OperationCanceledException>(() => task.TestTimeout());
 

--- a/src/Dtronix.Tests/Threading/Dispatcher/QueueResultAsyncTests.cs
+++ b/src/Dtronix.Tests/Threading/Dispatcher/QueueResultAsyncTests.cs
@@ -48,7 +48,7 @@ public class QueueResultAsyncTests
             await Task.Delay(500, ct);
             return true;
 
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.ThrowsAsync<OperationCanceledException>(() => task.TestTimeout());
 

--- a/src/Dtronix.Tests/Threading/Dispatcher/QueueResultTests.cs
+++ b/src/Dtronix.Tests/Threading/Dispatcher/QueueResultTests.cs
@@ -55,7 +55,7 @@ public class QueueResultTests
             }
 
             return true;
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.IsTrue(await task.TestTimeout());
     }

--- a/src/Dtronix.Tests/Threading/Dispatcher/QueueTests.cs
+++ b/src/Dtronix.Tests/Threading/Dispatcher/QueueTests.cs
@@ -64,7 +64,7 @@ public class QueueTests
             {
                 ct.ThrowIfCancellationRequested();
             }
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.ThrowsAsync<OperationCanceledException>(() => task.TestTimeout());
     }

--- a/src/Dtronix/Threading/Dispatcher/DispatcherPriority.cs
+++ b/src/Dtronix/Threading/Dispatcher/DispatcherPriority.cs
@@ -1,8 +1,0 @@
-﻿namespace Dtronix.Threading.Dispatcher;
-
-public enum DispatcherPriority
-{
-    Low,
-    Normal,
-    High,
-}

--- a/src/Dtronix/Threading/Dispatcher/ThreadDispatcher.cs
+++ b/src/Dtronix/Threading/Dispatcher/ThreadDispatcher.cs
@@ -3,10 +3,20 @@ using Dtronix.Threading.Dispatcher.Actions;
 
 namespace Dtronix.Threading.Dispatcher;
 
+public class ThreadDispatcherConfigurations
+{
+    public int ThreadCount { get; set; } = 1;
+
+    /// <summary>
+    /// Number 
+    /// </summary>
+    public int BoundCapacity { get; set; } = -1;
+
+    public int QueueCount { get; set; } = 1;
+}
+
 public class ThreadDispatcher : IDisposable
 {
-    private readonly int _threadCount;
-
     private class StopLoop : MessagePumpActionVoid
     {
     }
@@ -14,34 +24,37 @@ public class ThreadDispatcher : IDisposable
     private bool _isDisposed;
     public EventHandler<ThreadDispatcherExceptionEventArgs>? Exception;
 
+    private BlockingCollection<MessagePumpActionBase>[]? _queues;
+
     internal Thread[]? Threads;
-    protected BlockingCollection<MessagePumpActionBase>? InternalPriorityQueue;
-    protected BlockingCollection<MessagePumpActionBase>? HighPriorityQueue;
-    protected BlockingCollection<MessagePumpActionBase>? NormalPriorityQueue;
-    protected BlockingCollection<MessagePumpActionBase>? LowPriorityQueue;
     private CancellationTokenSource? _cancellationTokenSource;
+    private readonly ThreadDispatcherConfigurations _configs;
 
     public bool IsRunning => Threads != null;
 
     public ThreadDispatcher(int threadCount)
+        : this(new ThreadDispatcherConfigurations
+        {
+            BoundCapacity = -1,
+            ThreadCount = threadCount
+        })
+
     {
-        _threadCount = threadCount;
+
+    }
+
+    public ThreadDispatcher(ThreadDispatcherConfigurations configs)
+    {
+        _configs = configs ?? throw new ArgumentNullException(nameof(configs));
     }
 
     private void Pump()
     {
-        var queueList = new[]
-        {
-            InternalPriorityQueue,
-            HighPriorityQueue,
-            NormalPriorityQueue,
-            LowPriorityQueue
-        };
         try
         {
             while (true)
             {
-                var queueId = BlockingCollection<MessagePumpActionBase>.TakeFromAny(queueList!, out var action);
+                var queueId = BlockingCollection<MessagePumpActionBase>.TakeFromAny(_queues, out var action);
 
                 // Check if this is a command.
                 if (queueId == 0)
@@ -93,19 +106,23 @@ public class ThreadDispatcher : IDisposable
     /// <exception cref="InvalidOperationException"></exception>
     public bool Stop(int timeout = 1000)
     {
-        if (Threads == null)
+        if (Threads == null || _queues == null)
             throw new InvalidOperationException("Message pump is not running.");
 
         // Send enough StopLoop commands to end all the threads.
-        for (int i = 0; i < _threadCount; i++)
-            InternalPriorityQueue?.TryAdd(new StopLoop());
-            
+        for (int i = 0; i < _configs.ThreadCount; i++)
+            _queues[0].TryAdd(new StopLoop());
+
 
         _cancellationTokenSource?.Cancel();
-        InternalPriorityQueue?.CompleteAdding();
-        HighPriorityQueue?.CompleteAdding();
-        NormalPriorityQueue?.CompleteAdding();
-        LowPriorityQueue?.CompleteAdding();
+
+        foreach (var queue in _queues)
+        {
+            queue.CompleteAdding();
+            queue.Dispose();
+        }
+
+        _queues = null;
 
         var stopSuccessful = true;
         // Join all the threads back to ensure they are complete.
@@ -115,7 +132,7 @@ public class ThreadDispatcher : IDisposable
             if (!thread.Join(timeout))
                 stopSuccessful = false;
         }
-            
+
         Threads = null;
 
         return stopSuccessful;
@@ -130,15 +147,19 @@ public class ThreadDispatcher : IDisposable
         if (Threads != null)
             throw new InvalidOperationException("Message pump already running.");
 
-        InternalPriorityQueue = new BlockingCollection<MessagePumpActionBase>();
-        HighPriorityQueue = new BlockingCollection<MessagePumpActionBase>();
-        NormalPriorityQueue = new BlockingCollection<MessagePumpActionBase>();
-        LowPriorityQueue = new BlockingCollection<MessagePumpActionBase>();
+        _queues = new BlockingCollection<MessagePumpActionBase>[_configs.QueueCount + 1];
+        for (int i = 0; i < _queues.Length; i++)
+        {
+            // If the bound capacity is less than zero, it has no upper bound.
+            _queues[i] = _configs.BoundCapacity < 0
+                ? new BlockingCollection<MessagePumpActionBase>()
+                : new BlockingCollection<MessagePumpActionBase>(_configs.BoundCapacity);
+        }
 
         _cancellationTokenSource = new CancellationTokenSource();
 
-        Threads = new Thread[_threadCount];
-        for (int i = 0; i < _threadCount; i++)
+        Threads = new Thread[_configs.ThreadCount];
+        for (int i = 0; i < Threads.Length; i++)
         {
             Threads[i] = new Thread(Pump)
             {
@@ -146,49 +167,52 @@ public class ThreadDispatcher : IDisposable
             };
             Threads[i].Start();
         }
-            
+
     }
+
     public Task Queue(
         Action action,
-        DispatcherPriority priority = DispatcherPriority.Normal)
+        int priority = 0)
     {
         return Queue(new SimpleMessagePumpAction(action), priority);
     }
 
     public Task Queue(
         Action<CancellationToken> action,
-        DispatcherPriority priority = DispatcherPriority.Normal,
+        int priority = 0,
         CancellationToken cancellationToken = default)
     {
         return Queue(
             new SimpleMessagePumpActionCancellable(action, cancellationToken), priority);
     }
+
     public Task Queue(
         MessagePumpAction action,
-        DispatcherPriority priority = DispatcherPriority.Normal)
+        int priority = 0)
     {
         if (!IsRunning)
             throw new InvalidOperationException("ThreadDispatcher is not running");
 
-        GetQueue(priority).Add(action, action.CancellationToken);
+        _queues[priority + 1].Add(action, action.CancellationToken);
         return action.Result;
     }
 
     public Task QueueAsync(
         Func<CancellationToken, Task> action,
-        DispatcherPriority priority = DispatcherPriority.Normal,
+        int priority = 0,
         CancellationToken cancellationToken = default)
     {
         if (!IsRunning)
             throw new InvalidOperationException("ThreadDispatcher is not running");
 
         var messageTask = new SimpleMessagePumpTask(action, cancellationToken);
-        GetQueue(priority).Add(messageTask, cancellationToken);
+        _queues[priority + 1].Add(messageTask, cancellationToken);
         return messageTask.Result;
     }
+
     public Task<TResult> QueueResultAsync<TResult>(
         Func<CancellationToken, Task<TResult>> task,
-        DispatcherPriority priority = DispatcherPriority.Normal,
+        int priority = 0,
         CancellationToken cancellationToken = default)
     {
         return QueueResult(
@@ -197,7 +221,7 @@ public class ThreadDispatcher : IDisposable
 
     public Task<TResult> QueueResult<TResult>(
         Func<CancellationToken, TResult> action,
-        DispatcherPriority priority = DispatcherPriority.Normal,
+        int priority = 0,
         CancellationToken cancellationToken = default)
     {
         return QueueResult(
@@ -206,24 +230,13 @@ public class ThreadDispatcher : IDisposable
 
     public Task<TResult> QueueResult<TResult>(
         MessagePumpActionResult<TResult> action,
-        DispatcherPriority priority = DispatcherPriority.Normal)
+        int priority = 0)
     {
         if (!IsRunning)
             throw new InvalidOperationException("ThreadDispatcher is not running");
 
-        GetQueue(priority).Add(action, action.CancellationToken);
+        _queues[priority + 1].Add(action, action.CancellationToken);
         return action.Result;
-    }
-
-    private BlockingCollection<MessagePumpActionBase> GetQueue(DispatcherPriority priority)
-    {
-        return priority switch
-        {
-            DispatcherPriority.Low => LowPriorityQueue,
-            DispatcherPriority.Normal => NormalPriorityQueue,
-            DispatcherPriority.High => HighPriorityQueue,
-            _ => throw new ArgumentOutOfRangeException(nameof(priority), priority, null)
-        } ?? throw new InvalidOperationException();
     }
 
     public virtual void Dispose()
@@ -232,12 +245,7 @@ public class ThreadDispatcher : IDisposable
             return;
 
         _isDisposed = true;
-
         Stop();
-        InternalPriorityQueue?.Dispose();
-        HighPriorityQueue?.Dispose();
-        NormalPriorityQueue?.Dispose();
-        LowPriorityQueue?.Dispose();
         _cancellationTokenSource?.Dispose();
     }
 }

--- a/src/Dtronix/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
+++ b/src/Dtronix/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
@@ -1,0 +1,22 @@
+﻿namespace Dtronix.Threading.Dispatcher;
+
+/// <summary>
+/// Configurations for the <see cref="ThreadDispatcher"/> class.
+/// </summary>
+public class ThreadDispatcherConfiguration
+{
+    /// <summary>
+    /// Number of threads to run
+    /// </summary>
+    public int ThreadCount { get; set; } = 1;
+
+    /// <summary>
+    /// Number 
+    /// </summary>
+    public int BoundCapacity { get; set; } = -1;
+
+    /// <summary>
+    /// Number of queues to have running available.  Useful when you want to have prioritized queues.
+    /// </summary>
+    public int QueueCount { get; set; } = 1;
+}


### PR DESCRIPTION
This PR adds the ability to further configure the ThreadDispatcher to use as many queues as is desired and to configure the BlockingCollection<T>.BoundCapacity for each of the created queues.

This unfortunately introduces a breaking change with the removal of the DispatcherPriority enum as now accessing priorities are handled via a integer with the lower number having higher execution priority.