### PR TITLE
Real ThreadDispatcher Configurations

### DIFF
--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueAsyncTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueAsyncTests.cs
@@ -43,7 +43,7 @@ public class QueueAsyncTests
         var task = _dispatcher.QueueAsync(async ct =>
         {
             await Task.Delay(500, ct);
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.ThrowsAsync<OperationCanceledException>(() => task.TestTimeout());
 

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultAsyncTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultAsyncTests.cs
@@ -48,7 +48,7 @@ public class QueueResultAsyncTests
             await Task.Delay(500, ct);
             return true;
 
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.ThrowsAsync<OperationCanceledException>(() => task.TestTimeout());
 

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultTests.cs
@@ -54,7 +54,7 @@ public class QueueResultTests
             }
 
             return true;
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.IsTrue(await task.TestTimeout());
     }

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueTests.cs
@@ -64,7 +64,7 @@ public class QueueTests
             {
                 ct.ThrowIfCancellationRequested();
             }
-        }, DispatcherPriority.Normal, cts.Token);
+        }, 0, cts.Token);
 
         Assert.ThrowsAsync<OperationCanceledException>(() => task.TestTimeout());
     }

--- a/src/DtronixCommon/DtronixCommon.csproj
+++ b/src/DtronixCommon/DtronixCommon.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>0.2.4.0</Version>
+		<Version>0.3.0.0</Version>
 		<Nullable>enable</Nullable>
 		<LangVersion>10</LangVersion>
 		<Company>Dtronix</Company>

--- a/src/DtronixCommon/Threading/Dispatcher/DispatcherPriority.cs
+++ b/src/DtronixCommon/Threading/Dispatcher/DispatcherPriority.cs
@@ -1,8 +1,0 @@
-﻿namespace DtronixCommon.Threading.Dispatcher;
-
-public enum DispatcherPriority
-{
-    Low,
-    Normal,
-    High,
-}

--- a/src/DtronixCommon/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
+++ b/src/DtronixCommon/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using DtronixCommon.Threading.Dispatcher;
+﻿namespace DtronixCommon.Threading.Dispatcher;
 
 /// <summary>
 /// Configurations for the <see cref="ThreadDispatcher"/> class.

--- a/src/DtronixCommon/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
+++ b/src/DtronixCommon/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
@@ -1,0 +1,35 @@
+﻿using DtronixCommon.Threading.Dispatcher;
+
+/// <summary>
+/// Configurations for the <see cref="ThreadDispatcher"/> class.
+/// </summary>
+public class ThreadDispatcherConfiguration
+{
+    private int _queueCount = 1;
+
+    /// <summary>
+    /// Number of threads to run.
+    /// </summary>
+    public int ThreadCount { get; set; } = 1;
+
+    /// <summary>
+    /// Number of items each queue can hold.  Set to -1 to have the limit unbound.
+    /// </summary>
+    public int BoundCapacity { get; set; } = -1;
+
+    /// <summary>
+    /// Number of queues to have running available.  Useful when you want to have prioritized queues.
+    /// Number must be larger than 0.
+    /// </summary>
+    public int QueueCount
+    {
+        get => _queueCount;
+        set
+        {
+            if(value < 1)
+                throw new ArgumentOutOfRangeException(nameof(QueueCount), "Must be 1 or more.");
+
+            _queueCount = value;
+        }
+    }
+}

--- a/src/DtronixCommon/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
+++ b/src/DtronixCommon/Threading/Dispatcher/ThreadDispatcherConfiguration.cs
@@ -32,4 +32,10 @@ public class ThreadDispatcherConfiguration
             _queueCount = value;
         }
     }
+
+    /// <summary>
+    /// Sets the time the items are attempting to wait to be added to the queue in milliseconds.
+    /// Set to -1 to infinitely wait.
+    /// </summary>
+    public int QueueTryAddTimeout { get; set; } = 1500;
 }


### PR DESCRIPTION
This PR adds the ability to further configure the ThreadDispatcher to use as many queues as is desired and to configure the BlockingCollection.BoundCapacity for each of the created queues.


#### ThreadDispatcherConfiguration.cs
 - `QueueCount` - The number of queues for the dispatcher.
 - `BoundCapacity` - Number of items which can be added to each queue before rejection.
 - `ThreadCount` - Number of items which can be added to each queue before rejection.
 - `QueueTryAddTimeout` - Time spend waiting for a open spot in the queue then the `BoundCapacity` is reached.

This unfortunately introduces a breaking change with the removal of the DispatcherPriority enum as now accessing priorities are handled via a integer with the lower number having higher execution priority.
