### PR TITLE
QuadTree Performance Tuning

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,7 +3,7 @@ name: Build, Pack & Publish
 on:
   push:
     branches:
-      - '*'
+      - 'master'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.*
+        dotnet-version: 8.0.*
         source-url: https://api.nuget.org/v3/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/DtronixCommon.Tests/BoundaryTests.cs
+++ b/src/DtronixCommon.Tests/BoundaryTests.cs
@@ -10,13 +10,13 @@ public class BoundaryTests
     [Test]
     public void OneDimensionalBoundaryIsNotEmpty()
     {
-        Assert.IsFalse(new BoundaryF(0, -1, 0, 1).IsEmpty);
-        Assert.IsFalse(new BoundaryF(-1, 0, 1, 0).IsEmpty);
+        Assert.That(new BoundaryF(0, -1, 0, 1).IsEmpty, Is.False);
+        Assert.That(new BoundaryF(-1, 0, 1, 0).IsEmpty, Is.False);
     }
 
     [Test]
     public void CanUnionBoundariesWithOneDimension()
     {
-        Assert.AreEqual(new BoundaryF(-1, -1, 1, 1), new BoundaryF(0, -1, 0, 1).Union(new BoundaryF(-1, 0, 1, 0)));
+        Assert.That(new BoundaryF(0, -1, 0, 1).Union(new BoundaryF(-1, 0, 1, 0)), Is.EqualTo(new BoundaryF(-1, -1, 1, 1)));
     }
 }

--- a/src/DtronixCommon.Tests/Collections/BufferSequenceTests.cs
+++ b/src/DtronixCommon.Tests/Collections/BufferSequenceTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using DtronixCommon.Collections;
 using NUnit.Framework;
@@ -9,8 +9,8 @@ public class BufferSequenceTests
 {
     private void VerifySequence(BufferSequence.Range range, int expectedStart, int expectedEnd)
     {
-        Assert.AreEqual(expectedStart, range.Start, "Start");
-        Assert.AreEqual(expectedEnd, range.End, "End");
+        Assert.That(range.Start, Is.EqualTo(expectedStart), "Start");
+        Assert.That(range.End, Is.EqualTo(expectedEnd), "End");
     }
 
     [Test]
@@ -18,12 +18,12 @@ public class BufferSequenceTests
     {
         var bs = new BufferSequence(9);
 
-        Assert.Greater(bs.Rent(), -1);
-        Assert.Greater(bs.Rent(), -1);
+        Assert.That(bs.Rent(), Is.GreaterThan(-1));
+        Assert.That(bs.Rent(), Is.GreaterThan(-1));
 
-        Assert.AreEqual(0, bs.HeadIndex);
+        Assert.That(bs.HeadIndex, Is.EqualTo(0));
         bs.Return(0);
-        Assert.AreEqual(1, bs.HeadIndex);
+        Assert.That(bs.HeadIndex, Is.EqualTo(1));
     }
 
     [Test]
@@ -31,10 +31,10 @@ public class BufferSequenceTests
     {
         var bs = new BufferSequence(9);
         for (int i = 0; i < 10; i++)
-            Assert.Greater(bs.Rent(), -1);
+            Assert.That(bs.Rent(), Is.GreaterThan(-1));
 
         bs.Return(0);
-        Assert.AreEqual(0, bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(0));
     }
 
     [Test]
@@ -42,11 +42,11 @@ public class BufferSequenceTests
     {
         var bs = new BufferSequence(9);
         for (int i = 0; i < 10; i++)
-            Assert.Greater(bs.Rent(), -1);
+            Assert.That(bs.Rent(), Is.GreaterThan(-1));
 
-        Assert.AreEqual(9, bs.ConsumedTailIndex);
+        Assert.That(bs.ConsumedTailIndex, Is.EqualTo(9));
         bs.Return(9);
-        Assert.AreEqual(8, bs.ConsumedTailIndex);
+        Assert.That(bs.ConsumedTailIndex, Is.EqualTo(8));
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class BufferSequenceTests
         for (int i = 0; i < 10; i++)
             bs.Rent();
         bs.Return(9);
-        Assert.AreEqual(9, bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(9));
     }
 
     [Test]
@@ -65,15 +65,15 @@ public class BufferSequenceTests
         var bs = new BufferSequence(9);
         var value = bs.Rent();
         var value2 = bs.Rent();
-        Assert.AreEqual(0, value);
-        Assert.AreEqual(1, value2);
-        Assert.AreEqual(2, bs.Rent());
+        Assert.That(value, Is.EqualTo(0));
+        Assert.That(value2, Is.EqualTo(1));
+        Assert.That(bs.Rent(), Is.EqualTo(2));
 
         bs.Return(value);
-        Assert.AreEqual(0, bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(0));
 
         bs.Return(value2);
-        Assert.AreEqual(1, bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(1));
     }
 
     [Test]
@@ -83,7 +83,7 @@ public class BufferSequenceTests
         for (int i = 0; i < 11; i++)
             bs.Rent();
 
-        Assert.AreEqual(-1, bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(-1));
     }
 
     [Test]
@@ -95,7 +95,7 @@ public class BufferSequenceTests
 
         var result = bs.RentedSequences().ToArray();
 
-        Assert.AreEqual(1, result.Length);
+        Assert.That(result, Has.Length.EqualTo(1));
         VerifySequence(result[0], 0, 10);
     }
 
@@ -107,7 +107,7 @@ public class BufferSequenceTests
         for (int i = 0; i < 10; i++)
             items.Add(bs.Rent());
 
-        Assert.AreEqual(-1 , bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(-1));
     }
 
     [Test]
@@ -120,7 +120,7 @@ public class BufferSequenceTests
         bs.Return(0);
         var result = bs.RentedSequences().ToArray();
 
-        Assert.AreEqual(1, result.Length);
+        Assert.That(result, Has.Length.EqualTo(1));
         VerifySequence(result[0], 1, 10);
     }
 
@@ -134,7 +134,7 @@ public class BufferSequenceTests
         bs.Return(9);
         var result = bs.RentedSequences().ToArray();
 
-        Assert.AreEqual(1, result.Length);
+        Assert.That(result, Has.Length.EqualTo(1));
         VerifySequence(result[0], 0, 8);
     }
 
@@ -150,12 +150,12 @@ public class BufferSequenceTests
             bs.Return(i);
             var result = bs.RentedSequences().ToArray();
 
-            Assert.AreEqual(2, result.Length);
+            Assert.That(result, Has.Length.EqualTo(2));
 
             VerifySequence(result[0], 0, i - 1);
 
             VerifySequence(result[1], i + 1, 9);
-            Assert.AreEqual(i, bs.Rent());
+            Assert.That(bs.Rent(), Is.EqualTo(i));
         }
     }
 
@@ -174,7 +174,7 @@ public class BufferSequenceTests
 
         var result = bs.RentedSequences().ToArray();
 
-        Assert.AreEqual(5, result.Length);
+        Assert.That(result, Has.Length.EqualTo(5));
 
         VerifySequence(result[0], 0, 0);
         VerifySequence(result[1], 2, 2);
@@ -188,7 +188,7 @@ public class BufferSequenceTests
     {
         var bs = new BufferSequence(9);
         for (int i = 0; i < 10; i++)
-            Assert.Greater(bs.Rent(), -1);
+            Assert.That(bs.Rent(), Is.GreaterThan(-1));
 
         bs.Return(9);
         bs.Return(3);
@@ -196,11 +196,11 @@ public class BufferSequenceTests
         bs.Return(7);
         bs.Return(5);
 
-        Assert.AreEqual(1, bs.Rent());
-        Assert.AreEqual(3, bs.Rent());
-        Assert.AreEqual(5, bs.Rent());
-        Assert.AreEqual(7, bs.Rent());
-        Assert.AreEqual(9, bs.Rent());
+        Assert.That(bs.Rent(), Is.EqualTo(1));
+        Assert.That(bs.Rent(), Is.EqualTo(3));
+        Assert.That(bs.Rent(), Is.EqualTo(5));
+        Assert.That(bs.Rent(), Is.EqualTo(7));
+        Assert.That(bs.Rent(), Is.EqualTo(9));
     }
 
 
@@ -217,7 +217,7 @@ public class BufferSequenceTests
 
         var result = bs.RentedSequences().ToArray();
 
-        Assert.AreEqual(2, result.Length);
+        Assert.That(result, Has.Length.EqualTo(2));
         VerifySequence(result[0], 0, 3);
         VerifySequence(result[1], 7, 9);
     }
@@ -234,11 +234,11 @@ public class BufferSequenceTests
         bs.Return(7);
         bs.Return(8);
 
-        Assert.AreEqual(9, bs.ConsumedTailIndex);
+        Assert.That(bs.ConsumedTailIndex, Is.EqualTo(9));
 
         bs.Return(9);
 
-        Assert.AreEqual(6, bs.ConsumedTailIndex);
+        Assert.That(bs.ConsumedTailIndex, Is.EqualTo(6));
     }
 
     [Test]
@@ -253,11 +253,11 @@ public class BufferSequenceTests
         bs.Return(7);
         bs.Return(8);
 
-        Assert.AreEqual(3, bs.AvailableCount);
+        Assert.That(bs.AvailableCount, Is.EqualTo(3));
 
         bs.Return(9);
 
-        Assert.AreEqual(4, bs.AvailableCount);
+        Assert.That(bs.AvailableCount, Is.EqualTo(4));
     }
 
     [Test]
@@ -265,11 +265,11 @@ public class BufferSequenceTests
     {
         var bs = new BufferSequence(9);
         bs.Rent();
-        Assert.AreEqual(0, bs.HeadIndex);
-        Assert.AreEqual(0, bs.ConsumedTailIndex);
+        Assert.That(bs.HeadIndex, Is.EqualTo(0));
+        Assert.That(bs.ConsumedTailIndex, Is.EqualTo(0));
         bs.Return(0);
-        Assert.AreEqual(0, bs.Returned.count);
-        Assert.AreEqual(-1, bs.ConsumedTailIndex);
+        Assert.That(bs.Returned.count, Is.EqualTo(0));
+        Assert.That(bs.ConsumedTailIndex, Is.EqualTo(-1));
 
     }
 }

--- a/src/DtronixCommon.Tests/Collections/SimpleLinkedListTests.cs
+++ b/src/DtronixCommon.Tests/Collections/SimpleLinkedListTests.cs
@@ -16,13 +16,13 @@ public class SimpleLinkedListTests
             nodes[i] = linkedList.AddLast(i);
 
 
-        Assert.AreEqual(5, linkedList.Count);
-        Assert.AreEqual(nodes.Last(), linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(5));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes.Last()));
 
         linkedList.BreakAtNode(nodes[2], true);
 
-        Assert.AreEqual(2, linkedList.Count);
-        Assert.AreEqual(nodes[1], linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(2));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes[1]));
     }
 
     [Test]
@@ -33,13 +33,13 @@ public class SimpleLinkedListTests
         for (int i = 0; i < nodes.Length; i++)
             nodes[i] = linkedList.AddLast(i);
 
-        Assert.AreEqual(5, linkedList.Count);
-        Assert.AreEqual(nodes.Last(), linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(5));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes.Last()));
 
         linkedList.BreakAtNode(nodes[2], false);
 
-        Assert.AreEqual(2, linkedList.Count);
-        Assert.AreEqual(nodes[3], linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(2));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes[3]));
     }
 
 
@@ -53,9 +53,9 @@ public class SimpleLinkedListTests
 
         linkedList.BreakAtNode(nodes[0], false);
 
-        Assert.AreEqual(4, linkedList.Count);
-        Assert.AreEqual(nodes[1], linkedList.First);
-        Assert.AreEqual(nodes[4], linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(4));
+        Assert.That(linkedList.First, Is.EqualTo(nodes[1]));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes[4]));
     }
 
     [Test]
@@ -68,9 +68,9 @@ public class SimpleLinkedListTests
 
         linkedList.BreakAtNode(nodes[4], true);
 
-        Assert.AreEqual(4, linkedList.Count);
-        Assert.AreEqual(nodes[0], linkedList.First);
-        Assert.AreEqual(nodes[3], linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(4));
+        Assert.That(linkedList.First, Is.EqualTo(nodes[0]));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes[3]));
     }
 
     [Test]
@@ -83,9 +83,9 @@ public class SimpleLinkedListTests
 
         linkedList.BreakAtNode(nodes[1], true);
 
-        Assert.AreEqual(1, linkedList.Count);
-        Assert.AreEqual(nodes[0], linkedList.First);
-        Assert.AreEqual(nodes[0], linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(1));
+        Assert.That(linkedList.First, Is.EqualTo(nodes[0]));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes[0]));
     }
     [Test]
     public void BreakThreeItemNodeListBefore()
@@ -97,8 +97,8 @@ public class SimpleLinkedListTests
 
         linkedList.BreakAtNode(nodes[1], false);
 
-        Assert.AreEqual(1, linkedList.Count);
-        Assert.AreEqual(nodes[2], linkedList.First);
-        Assert.AreEqual(nodes[2], linkedList.Last);
+        Assert.That(linkedList.Count, Is.EqualTo(1));
+        Assert.That(linkedList.First, Is.EqualTo(nodes[2]));
+        Assert.That(linkedList.Last, Is.EqualTo(nodes[2]));
     }
 }

--- a/src/DtronixCommon.Tests/Collections/Trees/QuadTreeTests.g.cs
+++ b/src/DtronixCommon.Tests/Collections/Trees/QuadTreeTests.g.cs
@@ -23,8 +23,8 @@ public class FloatQuadTreeTests : QuadTreeTestBase
         qt.Insert(0, 0, 0, 0, item);
         qt.Insert(0, 0, 0, 0, item2);
 
-        Assert.AreEqual(0, item.QuadTreeId);
-        Assert.AreEqual(1, item2.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
+        Assert.That(item2.QuadTreeId, Is.EqualTo(1));
     }
 
     [Test]
@@ -34,7 +34,7 @@ public class FloatQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(0, 0, 0, 0, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -44,7 +44,7 @@ public class FloatQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(50, 50, 60, 60, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class FloatQuadTreeTests : QuadTreeTestBase
 
         var items = qt.Query(0, 0, 5, 5);
 
-        Assert.AreEqual(0, items.Count);
+        Assert.That(items.Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -75,10 +75,8 @@ public class FloatQuadTreeTests : QuadTreeTestBase
         var items = qt.Query(-1000, -1000, 1000, 1000);
         var items2 = qt.Query(-1000, -1000, 1000, 1000);
 
-        Assert.AreEqual(100, items.Count);
-        Assert.AreEqual(100, items2.Count);
-
-
+        Assert.That(items.Count, Is.EqualTo(100));
+        Assert.That(items2.Count, Is.EqualTo(100));
     }
 }
 
@@ -98,8 +96,8 @@ public class LongQuadTreeTests : QuadTreeTestBase
         qt.Insert(0, 0, 0, 0, item);
         qt.Insert(0, 0, 0, 0, item2);
 
-        Assert.AreEqual(0, item.QuadTreeId);
-        Assert.AreEqual(1, item2.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
+        Assert.That(item2.QuadTreeId, Is.EqualTo(1));
     }
 
     [Test]
@@ -109,7 +107,7 @@ public class LongQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(0, 0, 0, 0, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -119,7 +117,7 @@ public class LongQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(50, 50, 60, 60, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -131,7 +129,7 @@ public class LongQuadTreeTests : QuadTreeTestBase
 
         var items = qt.Query(0, 0, 5, 5);
 
-        Assert.AreEqual(0, items.Count);
+        Assert.That(items.Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -150,10 +148,8 @@ public class LongQuadTreeTests : QuadTreeTestBase
         var items = qt.Query(-1000, -1000, 1000, 1000);
         var items2 = qt.Query(-1000, -1000, 1000, 1000);
 
-        Assert.AreEqual(100, items.Count);
-        Assert.AreEqual(100, items2.Count);
-
-
+        Assert.That(items.Count, Is.EqualTo(100));
+        Assert.That(items2.Count, Is.EqualTo(100));
     }
 }
 
@@ -173,8 +169,8 @@ public class IntQuadTreeTests : QuadTreeTestBase
         qt.Insert(0, 0, 0, 0, item);
         qt.Insert(0, 0, 0, 0, item2);
 
-        Assert.AreEqual(0, item.QuadTreeId);
-        Assert.AreEqual(1, item2.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
+        Assert.That(item2.QuadTreeId, Is.EqualTo(1));
     }
 
     [Test]
@@ -184,7 +180,7 @@ public class IntQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(0, 0, 0, 0, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -194,7 +190,7 @@ public class IntQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(50, 50, 60, 60, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -206,7 +202,7 @@ public class IntQuadTreeTests : QuadTreeTestBase
 
         var items = qt.Query(0, 0, 5, 5);
 
-        Assert.AreEqual(0, items.Count);
+        Assert.That(items.Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -225,10 +221,8 @@ public class IntQuadTreeTests : QuadTreeTestBase
         var items = qt.Query(-1000, -1000, 1000, 1000);
         var items2 = qt.Query(-1000, -1000, 1000, 1000);
 
-        Assert.AreEqual(100, items.Count);
-        Assert.AreEqual(100, items2.Count);
-
-
+        Assert.That(items.Count, Is.EqualTo(100));
+        Assert.That(items2.Count, Is.EqualTo(100));
     }
 }
 
@@ -248,8 +242,8 @@ public class DoubleQuadTreeTests : QuadTreeTestBase
         qt.Insert(0, 0, 0, 0, item);
         qt.Insert(0, 0, 0, 0, item2);
 
-        Assert.AreEqual(0, item.QuadTreeId);
-        Assert.AreEqual(1, item2.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
+        Assert.That(item2.QuadTreeId, Is.EqualTo(1));
     }
 
     [Test]
@@ -259,7 +253,7 @@ public class DoubleQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(0, 0, 0, 0, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -269,7 +263,7 @@ public class DoubleQuadTreeTests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(50, 50, 60, 60, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -281,7 +275,7 @@ public class DoubleQuadTreeTests : QuadTreeTestBase
 
         var items = qt.Query(0, 0, 5, 5);
 
-        Assert.AreEqual(0, items.Count);
+        Assert.That(items.Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -300,10 +294,8 @@ public class DoubleQuadTreeTests : QuadTreeTestBase
         var items = qt.Query(-1000, -1000, 1000, 1000);
         var items2 = qt.Query(-1000, -1000, 1000, 1000);
 
-        Assert.AreEqual(100, items.Count);
-        Assert.AreEqual(100, items2.Count);
-
-
+        Assert.That(items.Count, Is.EqualTo(100));
+        Assert.That(items2.Count, Is.EqualTo(100));
     }
 }
 

--- a/src/DtronixCommon.Tests/Collections/Trees/QuadTreeTests.tt
+++ b/src/DtronixCommon.Tests/Collections/Trees/QuadTreeTests.tt
@@ -53,8 +53,8 @@ public class <#=config.ClassName#>Tests : QuadTreeTestBase
         qt.Insert(0, 0, 0, 0, item);
         qt.Insert(0, 0, 0, 0, item2);
 
-        Assert.AreEqual(0, item.QuadTreeId);
-        Assert.AreEqual(1, item2.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
+        Assert.That(item2.QuadTreeId, Is.EqualTo(1));
     }
 
     [Test]
@@ -64,7 +64,7 @@ public class <#=config.ClassName#>Tests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(0, 0, 0, 0, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -74,7 +74,7 @@ public class <#=config.ClassName#>Tests : QuadTreeTestBase
         var item = new TestQuadTreeItem();
         qt.Insert(50, 50, 60, 60, item);
 
-        Assert.AreEqual(0, item.QuadTreeId);
+        Assert.That(item.QuadTreeId, Is.EqualTo(0));
     }
 
     [Test]
@@ -86,7 +86,7 @@ public class <#=config.ClassName#>Tests : QuadTreeTestBase
 
         var items = qt.Query(0, 0, 5, 5);
 
-        Assert.AreEqual(0, items.Count);
+        Assert.That(items.Count, Is.EqualTo(0));
     }
 
     [Test]
@@ -105,10 +105,8 @@ public class <#=config.ClassName#>Tests : QuadTreeTestBase
         var items = qt.Query(-1000, -1000, 1000, 1000);
         var items2 = qt.Query(-1000, -1000, 1000, 1000);
 
-        Assert.AreEqual(100, items.Count);
-        Assert.AreEqual(100, items2.Count);
-
-
+        Assert.That(items.Count, Is.EqualTo(100));
+        Assert.That(items2.Count, Is.EqualTo(100));
     }
 }
 

--- a/src/DtronixCommon.Tests/DtronixCommon.Tests.csproj
+++ b/src/DtronixCommon.Tests/DtronixCommon.Tests.csproj
@@ -1,16 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="4.0.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DtronixCommon.Tests/Threading/DelayedActionTests.cs
+++ b/src/DtronixCommon.Tests/Threading/DelayedActionTests.cs
@@ -46,7 +46,7 @@ public class DelayedActionTests
         });
 
         await delayedAction.InvokeAsync();
-        Assert.IsTrue(await WaitForCompletion(100));
+        Assert.That(await WaitForCompletion(100), Is.True);
     }
 
 
@@ -59,11 +59,11 @@ public class DelayedActionTests
         });
 
         await delayedAction.InvokeAsync();
-        Assert.IsTrue(await WaitForCompletion(100));
+        Assert.That(await WaitForCompletion(100), Is.True);
 
         _tcs = new TaskCompletionSource();
         await delayedAction.InvokeAsync();
-        Assert.IsTrue(await WaitForCompletion(100));
+        Assert.That(await WaitForCompletion(100), Is.True);
 
     }
 
@@ -87,8 +87,8 @@ public class DelayedActionTests
         });
 
 
-        Assert.IsTrue(await WaitForCompletion(1000));
-        Assert.GreaterOrEqual(sw.ElapsedMilliseconds, 80);
+        Assert.That(await WaitForCompletion(1000), Is.True);
+        Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(80));
     }
 
     [Test]
@@ -106,6 +106,6 @@ public class DelayedActionTests
             await delayedAction.InvokeAsync(new ArgsValue(1));
         });
 
-        Assert.IsTrue(await WaitForCompletion(150));
+        Assert.That(await WaitForCompletion(150), Is.True);
     }
 }

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueAsyncTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueAsyncTests.cs
@@ -8,7 +8,13 @@ using NUnit.Framework;
 namespace DtronixCommon.Tests.Threading.Dispatcher;
 public class QueueAsyncTests
 {
-    private ThreadDispatcher _dispatcher;
+    private ThreadDispatcher? _dispatcher;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dispatcher?.Dispose();
+    }
 
     [SetUp]
     public void SetUp()

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueFireForgetTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueFireForgetTests.cs
@@ -10,7 +10,13 @@ namespace DtronixCommon.Tests.Threading.Dispatcher;
 
 public class QueueFireForgetTests
 {
-    private ThreadDispatcher _dispatcher;
+    private ThreadDispatcher? _dispatcher;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dispatcher?.Dispose();
+    }
 
     [SetUp]
     public void SetUp()

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultAsyncTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultAsyncTests.cs
@@ -9,7 +9,13 @@ namespace DtronixCommon.Tests.Threading.Dispatcher;
 
 public class QueueResultAsyncTests
 {
-    private ThreadDispatcher _dispatcher;
+    private ThreadDispatcher? _dispatcher;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dispatcher?.Dispose();
+    }
 
     [SetUp]
     public void SetUp()
@@ -24,7 +30,7 @@ public class QueueResultAsyncTests
     {
         var task = _dispatcher.QueueResultAsync(_ => Task.FromResult(true));
 
-        Assert.IsTrue(await task.TestTimeout());
+        Assert.That(await task.TestTimeout(), Is.True);
     }
 
     [Test]
@@ -36,7 +42,7 @@ public class QueueResultAsyncTests
             return true;
         });
 
-        Assert.IsTrue(await task.TestTimeout());
+        Assert.That(await task.TestTimeout(), Is.True);
     }
 
     [Test]

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueResultTests.cs
@@ -9,7 +9,13 @@ namespace DtronixCommon.Tests.Threading.Dispatcher;
 public class QueueResultTests
 {
 
-    private ThreadDispatcher _dispatcher;
+    private ThreadDispatcher? _dispatcher;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dispatcher?.Dispose();
+    }
 
     [SetUp]
     public void SetUp()
@@ -28,7 +34,7 @@ public class QueueResultTests
             return true;
         });
 
-        Assert.IsTrue(await task.TestTimeout());
+        Assert.That(await task.TestTimeout(), Is.True);
     }
 
     [Test]
@@ -40,7 +46,7 @@ public class QueueResultTests
             return true;
         });
 
-        Assert.IsTrue(await task.TestTimeout());
+        Assert.That(await task.TestTimeout(), Is.True);
     }
 
     [Test]
@@ -56,7 +62,7 @@ public class QueueResultTests
             return true;
         }, 0, cts.Token);
 
-        Assert.IsTrue(await task.TestTimeout());
+        Assert.That(await task.TestTimeout(), Is.True);
     }
 
   

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/QueueTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/QueueTests.cs
@@ -11,7 +11,13 @@ namespace DtronixCommon.Tests.Threading.Dispatcher;
 
 public class QueueTests
 {
-    private ThreadDispatcher _dispatcher;
+    private ThreadDispatcher? _dispatcher;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _dispatcher?.Dispose();
+    }
 
     [SetUp]
     public void SetUp()
@@ -47,12 +53,12 @@ public class QueueTests
         });
 
         task.AssertTimesOut(50);
-        
-        Assert.IsTrue(started);
-        Assert.IsFalse(completed);
+
+        Assert.That(started, Is.True);
+        Assert.That(completed, Is.False);
 
         await task.TestTimeout();
-        Assert.IsTrue(completed);
+        Assert.That(completed, Is.True);
     }
 
     [Test]
@@ -84,19 +90,19 @@ public class QueueTests
     [Test]
     public async Task MessagePump_IsInvokePending_FalseOnEmptyQueue()
     {
-        Assert.IsFalse(_dispatcher.IsInvokePending);
+        Assert.That(_dispatcher.IsInvokePending, Is.False);
         await _dispatcher.Queue(new SimpleMessagePumpAction(() =>
         {
             Thread.Sleep(100);
         })).TestTimeout();
 
-        Assert.IsFalse(_dispatcher.IsInvokePending);
+        Assert.That(_dispatcher.IsInvokePending, Is.False);
     }
 
     [Test]
     public async Task MessagePump_IsInvokePending_TrueOnItemInQueue()
     {
-        Assert.IsFalse(_dispatcher.IsInvokePending);
+        Assert.That(_dispatcher.IsInvokePending, Is.False);
         _ = _dispatcher.Queue(new SimpleMessagePumpAction(() =>
         {
             Thread.Sleep(1000);
@@ -105,13 +111,13 @@ public class QueueTests
         // Delay added to allow the item to queue and start executing.
         await Task.Delay(100);
 
-        Assert.IsFalse(_dispatcher.IsInvokePending);
+        Assert.That(_dispatcher.IsInvokePending, Is.False);
 
         _ = _dispatcher.Queue(new SimpleMessagePumpAction(() =>
         {
         })).TestTimeout();
 
-        Assert.IsTrue(_dispatcher.IsInvokePending);
+        Assert.That(_dispatcher.IsInvokePending, Is.True);
     }
 
     [Test]
@@ -130,10 +136,10 @@ public class QueueTests
                 Thread.Sleep(10000);
             }));
 
-        Assert.IsTrue(fire());
-        Assert.IsTrue(fire());
-        Assert.IsFalse(fire());
-        Assert.GreaterOrEqual(sw.ElapsedMilliseconds, 190);
+        Assert.That(fire(), Is.True);
+        Assert.That(fire(), Is.True);
+        Assert.That(fire(), Is.False);
+        Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(190));
     }
 
     [Test]
@@ -152,9 +158,9 @@ public class QueueTests
             Thread.Sleep(10000);
         }));
 
-        Assert.IsTrue(fire());
+        Assert.That(fire(), Is.True);
         fire();
-        Assert.IsFalse(fire());
-        Assert.LessOrEqual(sw.ElapsedMilliseconds, 500);
+        Assert.That(fire(), Is.False);
+        Assert.That(sw.ElapsedMilliseconds, Is.LessThanOrEqualTo(500));
     }
 }

--- a/src/DtronixCommon.Tests/Threading/Dispatcher/ThreadDispatcherTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Dispatcher/ThreadDispatcherTests.cs
@@ -24,7 +24,7 @@ public class ThreadDispatcherTests
             complete = true;
         });
 
-        tasks[1] = dispatcher.Queue(() => { Assert.IsTrue(complete); });
+        tasks[1] = dispatcher.Queue(() => { Assert.That(complete, Is.True); });
         await Task.WhenAll(tasks).TestTimeout();
     }
 
@@ -40,7 +40,7 @@ public class ThreadDispatcherTests
             var i1 = i;
             tasks[i] = dispatcher.Queue(() =>
             {
-                Assert.AreEqual(i1, counter++, "Executed tasks out of order.");
+                Assert.That(counter++, Is.EqualTo(i1), "Executed tasks out of order.");
             });
         }
 
@@ -65,8 +65,8 @@ public class ThreadDispatcherTests
         await Task.Delay(100);
         var task2 = dispatcher.QueueAsync( _ =>
         {
-            Assert.IsTrue(task1Started);
-            Assert.IsFalse(task1Completed);
+            Assert.That(task1Started, Is.True);
+            Assert.That(task1Completed, Is.False);
             return Task.CompletedTask;
         });
 
@@ -82,12 +82,12 @@ public class ThreadDispatcherTests
         var threads = dispatcher.Threads;
 
         foreach (var dispatcherThread in threads)
-            Assert.IsTrue(dispatcherThread.ThreadState.HasFlag(ThreadState.Background));
+            Assert.That(dispatcherThread.ThreadState.HasFlag(ThreadState.Background), Is.True);
 
-        Assert.IsTrue(dispatcher.Stop());
+        Assert.That(dispatcher.Stop(), Is.True);
 
         foreach (var dispatcherThread in threads)
-            Assert.IsFalse(dispatcherThread.IsAlive);
+            Assert.That(dispatcherThread.IsAlive, Is.False);
 
     }
 
@@ -172,7 +172,7 @@ public class ThreadDispatcherTests
         // Dummy action.
         await dispatcher.Queue(() => { });
 
-        Assert.AreEqual(1, wrapperCallCount);
+        Assert.That(wrapperCallCount, Is.EqualTo(1));
     }
 
     [Test]
@@ -187,7 +187,7 @@ public class ThreadDispatcherTests
             dispatcher.QueueFireForget(_ => { Thread.Sleep(250); });
         }
 
-        Assert.IsTrue(dispatcher.Stop(400));
+        Assert.That(dispatcher.Stop(400), Is.True);
     }
 
 

--- a/src/DtronixCommon.Tests/Threading/Tasks/ReusableTaskCompletionTests.cs
+++ b/src/DtronixCommon.Tests/Threading/Tasks/ReusableTaskCompletionTests.cs
@@ -31,11 +31,11 @@ public class ReusableTaskCompletionTests
             manualReset.TrySetCanceled();
             manualReset.Reset();
         });
-        Assert.IsTrue(await manualReset.Awaiter);
+        Assert.That(await manualReset.Awaiter, Is.True);
 
         // Spin while the task resets.
         await Task.Delay(1);
-        Assert.IsFalse(await manualReset.Awaiter);
+        Assert.That(await manualReset.Awaiter, Is.False);
 
         // Spin while the task resets.
         await Task.Delay(1);
@@ -78,12 +78,12 @@ public class ReusableTaskCompletionTests
             manualReset.Reset();
         });
         await manualReset.Awaiter;
-        Assert.IsTrue(setResult1);
+        Assert.That(setResult1, Is.True);
 
         // Spin while the task resets.
         await Task.Delay(1);
         await manualReset.Awaiter;
-        Assert.IsTrue(setResult2);
+        Assert.That(setResult2, Is.True);
 
         // Spin while the task resets.
         await Task.Delay(1);

--- a/src/DtronixCommon.sln
+++ b/src/DtronixCommon.sln
@@ -12,6 +12,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{99E0DD64-D79C-4A3D-A7E8-A2810D212CE5}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		..\.github\workflows\dotnet.yml = ..\.github\workflows\dotnet.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DtronixCommonBenchmarks", "DtronixCommonBenchmarks\DtronixCommonBenchmarks.csproj", "{48AA31E7-0494-4FBA-8CD7-C00BDB0CB9A9}"

--- a/src/DtronixCommon/Collections/Lists/Lists.g.cs
+++ b/src/DtronixCommon/Collections/Lists/Lists.g.cs
@@ -60,7 +60,7 @@ public class FloatList : IDisposable
     /// <summary>
     /// Contains the data.
     /// </summary>
-    private float[]? _data;
+    public float[]? Data;
 
     /// <summary>
     /// Number of fields which are used in the list.  This number is multuplied 
@@ -102,7 +102,7 @@ public class FloatList : IDisposable
     public FloatList(int fieldCount, int capacity)
     {
         _numFields = fieldCount;
-        _data = new float[capacity];
+        Data = new float[capacity];
     }
 
     /// <summary>
@@ -115,7 +115,7 @@ public class FloatList : IDisposable
     public float Get(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        return _data![index * _numFields + field];
+        return Data![index * _numFields + field];
     }
 
     /// <summary>
@@ -131,7 +131,7 @@ public class FloatList : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<float> Get(int index, int fieldStart, int fieldCount)
     {
-        return new ReadOnlySpan<float>(_data, index * _numFields + fieldStart, fieldCount);
+        return new ReadOnlySpan<float>(Data, index * _numFields + fieldStart, fieldCount);
     }
 
     /// <summary>
@@ -154,7 +154,7 @@ public class FloatList : IDisposable
     public void Set(int index, int field, float value)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field] = value;
+        Data![index * _numFields + field] = value;
     }
 
     /// <summary>
@@ -176,15 +176,15 @@ public class FloatList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new float[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
         return InternalCount++;
@@ -200,20 +200,75 @@ public class FloatList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new float[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
-        values.CopyTo(_data.AsSpan(InternalCount * _numFields));
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
 
         return InternalCount++;
+    }
+
+    /// <summary>
+    /// Inserts an element to the back of the list and adds the passed values to the data.
+    /// </summary>
+    /// <returns></returns>
+    public int PushBackCount(ReadOnlySpan<float> values, int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new float[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
+
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
+
+        var id = InternalCount;
+        InternalCount += count;
+        return id;
+    }
+
+
+    /// <summary>
+    /// Ensures that the list has enough space to accommodate a specified number of additional elements.
+    /// </summary>
+    /// <param name="count">The number of additional elements that the list needs to accommodate.</param>
+    /// <returns>The current count of elements in the list before the operation.</returns>
+    /// <remarks>
+    /// If the list does not have enough space, it reallocates the buffer, doubling its size, to make room for the new elements.
+    /// </remarks>
+    public void EnsureSpaceAvailable(int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new float[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
     }
 
     /// <summary>
@@ -229,13 +284,13 @@ public class FloatList : IDisposable
     public void Increment(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]++;
+        Data![index * _numFields + field]++;
     }
 
     public void Decrement(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]--;
+        Data![index * _numFields + field]--;
     }
 
     /// <summary>
@@ -251,7 +306,7 @@ public class FloatList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
             return index;
@@ -274,10 +329,10 @@ public class FloatList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
-            values.CopyTo(_data.AsSpan(index * _numFields));
+            values.CopyTo(Data.AsSpan(index * _numFields));
             return index;
         }
 
@@ -293,7 +348,7 @@ public class FloatList : IDisposable
     {
         // Push the element to the free list.
         int pos = index * _numFields;
-        _data![pos] = _freeElement;
+        Data![pos] = _freeElement;
         _freeElement = index;
     }
 
@@ -302,7 +357,7 @@ public class FloatList : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _data = null;
+        Data = null;
     }
 }
 
@@ -356,7 +411,7 @@ public class DoubleList : IDisposable
     /// <summary>
     /// Contains the data.
     /// </summary>
-    private double[]? _data;
+    public double[]? Data;
 
     /// <summary>
     /// Number of fields which are used in the list.  This number is multuplied 
@@ -398,7 +453,7 @@ public class DoubleList : IDisposable
     public DoubleList(int fieldCount, int capacity)
     {
         _numFields = fieldCount;
-        _data = new double[capacity];
+        Data = new double[capacity];
     }
 
     /// <summary>
@@ -411,7 +466,7 @@ public class DoubleList : IDisposable
     public double Get(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        return _data![index * _numFields + field];
+        return Data![index * _numFields + field];
     }
 
     /// <summary>
@@ -427,7 +482,7 @@ public class DoubleList : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<double> Get(int index, int fieldStart, int fieldCount)
     {
-        return new ReadOnlySpan<double>(_data, index * _numFields + fieldStart, fieldCount);
+        return new ReadOnlySpan<double>(Data, index * _numFields + fieldStart, fieldCount);
     }
 
     /// <summary>
@@ -450,7 +505,7 @@ public class DoubleList : IDisposable
     public void Set(int index, int field, double value)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field] = value;
+        Data![index * _numFields + field] = value;
     }
 
     /// <summary>
@@ -472,15 +527,15 @@ public class DoubleList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new double[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
         return InternalCount++;
@@ -496,20 +551,75 @@ public class DoubleList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new double[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
-        values.CopyTo(_data.AsSpan(InternalCount * _numFields));
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
 
         return InternalCount++;
+    }
+
+    /// <summary>
+    /// Inserts an element to the back of the list and adds the passed values to the data.
+    /// </summary>
+    /// <returns></returns>
+    public int PushBackCount(ReadOnlySpan<double> values, int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new double[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
+
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
+
+        var id = InternalCount;
+        InternalCount += count;
+        return id;
+    }
+
+
+    /// <summary>
+    /// Ensures that the list has enough space to accommodate a specified number of additional elements.
+    /// </summary>
+    /// <param name="count">The number of additional elements that the list needs to accommodate.</param>
+    /// <returns>The current count of elements in the list before the operation.</returns>
+    /// <remarks>
+    /// If the list does not have enough space, it reallocates the buffer, doubling its size, to make room for the new elements.
+    /// </remarks>
+    public void EnsureSpaceAvailable(int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new double[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
     }
 
     /// <summary>
@@ -525,13 +635,13 @@ public class DoubleList : IDisposable
     public void Increment(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]++;
+        Data![index * _numFields + field]++;
     }
 
     public void Decrement(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]--;
+        Data![index * _numFields + field]--;
     }
 
     /// <summary>
@@ -547,7 +657,7 @@ public class DoubleList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
             return index;
@@ -570,10 +680,10 @@ public class DoubleList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
-            values.CopyTo(_data.AsSpan(index * _numFields));
+            values.CopyTo(Data.AsSpan(index * _numFields));
             return index;
         }
 
@@ -589,7 +699,7 @@ public class DoubleList : IDisposable
     {
         // Push the element to the free list.
         int pos = index * _numFields;
-        _data![pos] = _freeElement;
+        Data![pos] = _freeElement;
         _freeElement = index;
     }
 
@@ -598,7 +708,7 @@ public class DoubleList : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _data = null;
+        Data = null;
     }
 }
 
@@ -652,7 +762,7 @@ public class IntList : IDisposable
     /// <summary>
     /// Contains the data.
     /// </summary>
-    private int[]? _data;
+    public int[]? Data;
 
     /// <summary>
     /// Number of fields which are used in the list.  This number is multuplied 
@@ -694,7 +804,7 @@ public class IntList : IDisposable
     public IntList(int fieldCount, int capacity)
     {
         _numFields = fieldCount;
-        _data = new int[capacity];
+        Data = new int[capacity];
     }
 
     /// <summary>
@@ -707,7 +817,7 @@ public class IntList : IDisposable
     public int Get(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        return _data![index * _numFields + field];
+        return Data![index * _numFields + field];
     }
 
     /// <summary>
@@ -723,7 +833,7 @@ public class IntList : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<int> Get(int index, int fieldStart, int fieldCount)
     {
-        return new ReadOnlySpan<int>(_data, index * _numFields + fieldStart, fieldCount);
+        return new ReadOnlySpan<int>(Data, index * _numFields + fieldStart, fieldCount);
     }
 
     /// <summary>
@@ -746,7 +856,7 @@ public class IntList : IDisposable
     public void Set(int index, int field, int value)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field] = value;
+        Data![index * _numFields + field] = value;
     }
 
     /// <summary>
@@ -768,15 +878,15 @@ public class IntList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new int[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
         return InternalCount++;
@@ -792,20 +902,75 @@ public class IntList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new int[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
-        values.CopyTo(_data.AsSpan(InternalCount * _numFields));
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
 
         return InternalCount++;
+    }
+
+    /// <summary>
+    /// Inserts an element to the back of the list and adds the passed values to the data.
+    /// </summary>
+    /// <returns></returns>
+    public int PushBackCount(ReadOnlySpan<int> values, int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new int[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
+
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
+
+        var id = InternalCount;
+        InternalCount += count;
+        return id;
+    }
+
+
+    /// <summary>
+    /// Ensures that the list has enough space to accommodate a specified number of additional elements.
+    /// </summary>
+    /// <param name="count">The number of additional elements that the list needs to accommodate.</param>
+    /// <returns>The current count of elements in the list before the operation.</returns>
+    /// <remarks>
+    /// If the list does not have enough space, it reallocates the buffer, doubling its size, to make room for the new elements.
+    /// </remarks>
+    public void EnsureSpaceAvailable(int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new int[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
     }
 
     /// <summary>
@@ -821,13 +986,13 @@ public class IntList : IDisposable
     public void Increment(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]++;
+        Data![index * _numFields + field]++;
     }
 
     public void Decrement(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]--;
+        Data![index * _numFields + field]--;
     }
 
     /// <summary>
@@ -843,7 +1008,7 @@ public class IntList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
             return index;
@@ -866,10 +1031,10 @@ public class IntList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
-            values.CopyTo(_data.AsSpan(index * _numFields));
+            values.CopyTo(Data.AsSpan(index * _numFields));
             return index;
         }
 
@@ -885,7 +1050,7 @@ public class IntList : IDisposable
     {
         // Push the element to the free list.
         int pos = index * _numFields;
-        _data![pos] = _freeElement;
+        Data![pos] = _freeElement;
         _freeElement = index;
     }
 
@@ -894,7 +1059,7 @@ public class IntList : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _data = null;
+        Data = null;
     }
 }
 
@@ -948,7 +1113,7 @@ public class LongList : IDisposable
     /// <summary>
     /// Contains the data.
     /// </summary>
-    private long[]? _data;
+    public long[]? Data;
 
     /// <summary>
     /// Number of fields which are used in the list.  This number is multuplied 
@@ -990,7 +1155,7 @@ public class LongList : IDisposable
     public LongList(int fieldCount, int capacity)
     {
         _numFields = fieldCount;
-        _data = new long[capacity];
+        Data = new long[capacity];
     }
 
     /// <summary>
@@ -1003,7 +1168,7 @@ public class LongList : IDisposable
     public long Get(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        return _data![index * _numFields + field];
+        return Data![index * _numFields + field];
     }
 
     /// <summary>
@@ -1019,7 +1184,7 @@ public class LongList : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<long> Get(int index, int fieldStart, int fieldCount)
     {
-        return new ReadOnlySpan<long>(_data, index * _numFields + fieldStart, fieldCount);
+        return new ReadOnlySpan<long>(Data, index * _numFields + fieldStart, fieldCount);
     }
 
     /// <summary>
@@ -1042,7 +1207,7 @@ public class LongList : IDisposable
     public void Set(int index, int field, long value)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field] = value;
+        Data![index * _numFields + field] = value;
     }
 
     /// <summary>
@@ -1064,15 +1229,15 @@ public class LongList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new long[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
         return InternalCount++;
@@ -1088,20 +1253,75 @@ public class LongList : IDisposable
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new long[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
-        values.CopyTo(_data.AsSpan(InternalCount * _numFields));
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
 
         return InternalCount++;
+    }
+
+    /// <summary>
+    /// Inserts an element to the back of the list and adds the passed values to the data.
+    /// </summary>
+    /// <returns></returns>
+    public int PushBackCount(ReadOnlySpan<long> values, int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new long[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
+
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
+
+        var id = InternalCount;
+        InternalCount += count;
+        return id;
+    }
+
+
+    /// <summary>
+    /// Ensures that the list has enough space to accommodate a specified number of additional elements.
+    /// </summary>
+    /// <param name="count">The number of additional elements that the list needs to accommodate.</param>
+    /// <returns>The current count of elements in the list before the operation.</returns>
+    /// <remarks>
+    /// If the list does not have enough space, it reallocates the buffer, doubling its size, to make room for the new elements.
+    /// </remarks>
+    public void EnsureSpaceAvailable(int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new long[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
     }
 
     /// <summary>
@@ -1117,13 +1337,13 @@ public class LongList : IDisposable
     public void Increment(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]++;
+        Data![index * _numFields + field]++;
     }
 
     public void Decrement(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]--;
+        Data![index * _numFields + field]--;
     }
 
     /// <summary>
@@ -1139,7 +1359,7 @@ public class LongList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
             return index;
@@ -1162,10 +1382,10 @@ public class LongList : IDisposable
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
-            values.CopyTo(_data.AsSpan(index * _numFields));
+            values.CopyTo(Data.AsSpan(index * _numFields));
             return index;
         }
 
@@ -1181,7 +1401,7 @@ public class LongList : IDisposable
     {
         // Push the element to the free list.
         int pos = index * _numFields;
-        _data![pos] = _freeElement;
+        Data![pos] = _freeElement;
         _freeElement = index;
     }
 
@@ -1190,6 +1410,6 @@ public class LongList : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _data = null;
+        Data = null;
     }
 }

--- a/src/DtronixCommon/Collections/Lists/Lists.tt
+++ b/src/DtronixCommon/Collections/Lists/Lists.tt
@@ -96,7 +96,7 @@ namespace DtronixCommon.Collections.Lists;
     /// <summary>
     /// Contains the data.
     /// </summary>
-    private <#=config.NumberType#>[]? _data;
+    public <#=config.NumberType#>[]? Data;
 
     /// <summary>
     /// Number of fields which are used in the list.  This number is multuplied 
@@ -138,7 +138,7 @@ namespace DtronixCommon.Collections.Lists;
     public <#=config.ClassName#>(int fieldCount, int capacity)
     {
         _numFields = fieldCount;
-        _data = new <#=config.NumberType#>[capacity];
+        Data = new <#=config.NumberType#>[capacity];
     }
 
     /// <summary>
@@ -151,7 +151,7 @@ namespace DtronixCommon.Collections.Lists;
     public <#=config.NumberType#> Get(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        return _data![index * _numFields + field];
+        return Data![index * _numFields + field];
     }
 
     /// <summary>
@@ -167,7 +167,7 @@ namespace DtronixCommon.Collections.Lists;
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<<#=config.NumberType#>> Get(int index, int fieldStart, int fieldCount)
     {
-        return new ReadOnlySpan<<#=config.NumberType#>>(_data, index * _numFields + fieldStart, fieldCount);
+        return new ReadOnlySpan<<#=config.NumberType#>>(Data, index * _numFields + fieldStart, fieldCount);
     }
 
     /// <summary>
@@ -190,7 +190,7 @@ namespace DtronixCommon.Collections.Lists;
     public void Set(int index, int field, <#=config.NumberType#> value)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field] = value;
+        Data![index * _numFields + field] = value;
     }
 
     /// <summary>
@@ -212,15 +212,15 @@ namespace DtronixCommon.Collections.Lists;
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new <#=config.NumberType#>[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
         return InternalCount++;
@@ -236,20 +236,75 @@ namespace DtronixCommon.Collections.Lists;
 
         // If the list is full, we need to reallocate the buffer to make room
         // for the new element.
-        if (newPos > _data!.Length)
+        if (newPos > Data!.Length)
         {
             // Use double the size for the new capacity.
             int newCap = newPos * 2;
 
             // Allocate new array and copy former contents.
             var newArray = new <#=config.NumberType#>[newCap];
-            Array.Copy(_data, newArray, _data.Length);
-            _data = newArray;
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
         }
 
-        values.CopyTo(_data.AsSpan(InternalCount * _numFields));
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
 
         return InternalCount++;
+    }
+
+    /// <summary>
+    /// Inserts an element to the back of the list and adds the passed values to the data.
+    /// </summary>
+    /// <returns></returns>
+    public int PushBackCount(ReadOnlySpan<<#=config.NumberType#>> values, int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new <#=config.NumberType#>[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
+
+        values.CopyTo(Data.AsSpan(InternalCount * _numFields));
+
+        var id = InternalCount;
+        InternalCount += count;
+        return id;
+    }
+
+
+    /// <summary>
+    /// Ensures that the list has enough space to accommodate a specified number of additional elements.
+    /// </summary>
+    /// <param name="count">The number of additional elements that the list needs to accommodate.</param>
+    /// <returns>The current count of elements in the list before the operation.</returns>
+    /// <remarks>
+    /// If the list does not have enough space, it reallocates the buffer, doubling its size, to make room for the new elements.
+    /// </remarks>
+    public void EnsureSpaceAvailable(int count)
+    {
+        int newPos = (InternalCount + count) * _numFields;
+
+        // If the list is full, we need to reallocate the buffer to make room
+        // for the new element.
+        if (newPos > Data!.Length)
+        {
+            // Use double the size for the new capacity.
+            int newCap = newPos * 2;
+
+            // Allocate new array and copy former contents.
+            var newArray = new <#=config.NumberType#>[newCap];
+            Array.Copy(Data, newArray, Data.Length);
+            Data = newArray;
+        }
     }
 
     /// <summary>
@@ -265,13 +320,13 @@ namespace DtronixCommon.Collections.Lists;
     public void Increment(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]++;
+        Data![index * _numFields + field]++;
     }
 
     public void Decrement(int index, int field)
     {
         Debug.Assert(index >= 0 && index < InternalCount && field >= 0 && field < _numFields);
-        _data![index * _numFields + field]--;
+        Data![index * _numFields + field]--;
     }
 
     /// <summary>
@@ -287,7 +342,7 @@ namespace DtronixCommon.Collections.Lists;
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
             return index;
@@ -310,10 +365,10 @@ namespace DtronixCommon.Collections.Lists;
             int pos = index * _numFields;
 
             // Set the free index to the next free index.
-            _freeElement = (int)_data![pos];
+            _freeElement = (int)Data![pos];
 
             // Return the free index.
-            values.CopyTo(_data.AsSpan(index * _numFields));
+            values.CopyTo(Data.AsSpan(index * _numFields));
             return index;
         }
 
@@ -329,7 +384,7 @@ namespace DtronixCommon.Collections.Lists;
     {
         // Push the element to the free list.
         int pos = index * _numFields;
-        _data![pos] = _freeElement;
+        Data![pos] = _freeElement;
         _freeElement = index;
     }
 
@@ -338,7 +393,7 @@ namespace DtronixCommon.Collections.Lists;
     /// </summary>
     public void Dispose()
     {
-        _data = null;
+        Data = null;
     }
 }
 <#

--- a/src/DtronixCommon/Collections/Trees/QuadTrees.g.cs
+++ b/src/DtronixCommon/Collections/Trees/QuadTrees.g.cs
@@ -52,7 +52,14 @@ public class FloatQuadTree<T> : IDisposable
     const int _nodeIdxFc = 0;
 
     // Stores the number of elements in the node or -1 if it is not a leaf.
-    static int _nodeIdxNum = 1;
+    const int _nodeIdxNum = 1;
+
+    /// <summary>
+    /// A static array of integers used as the default values for new child nodes in the quadtree. 
+    /// These values are used when a leaf node in the quadtree is full and needs to be split into four child nodes.
+    /// Each pair of -1 and 0 in the array represents the initial state of a child node, where -1 indicates that the node is empty and 0 indicates that the node has no elements.
+    /// </summary>
+    private static readonly int[] _defaultNode4Values = new[] { -1, 0, -1, 0, -1, 0, -1, 0, };
 
     // Stores all the nodes in the quadtree. The first node in this
     // sequence is always the root.
@@ -157,7 +164,7 @@ public class FloatQuadTree<T> : IDisposable
 
         if (property == null)
             throw new Exception(
-                $"Type {typeof(T).FullName} does not contain a interger property named QuadTreeId as required.");
+                $"Type {typeof(T).FullName} does not contain a integer property named QuadTreeId as required.");
 
         _quadTreeIdSetter = property.GetBackingField().CreateSetter<T, int>();
     }
@@ -186,7 +193,7 @@ public class FloatQuadTree<T> : IDisposable
         items[newElement] = element;
 
         // Insert the element to the appropriate leaf node(s).
-        node_insert(new ReadOnlySpan<float>(_rootNode), bounds, newElement);
+        NodeInsert(new ReadOnlySpan<float>(_rootNode), bounds, newElement);
          _quadTreeIdSetter(element, newElement);
         return newElement;
     }
@@ -199,20 +206,17 @@ public class FloatQuadTree<T> : IDisposable
     {
         var id = element.QuadTreeId;
         // Find the leaves.
-        var leaves = find_leaves(
+        var leaves = FindLeaves(
             new ReadOnlySpan<float>(_rootNode),
             _eleBounds.Get(id, 0, 4));
-
-        int nodeIndex;
-        int ndIndex;
 
         // For each leaf node, remove the element node.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list until we find the element node.
-            nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
+            var nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             int prevIndex = -1;
             while (nodeIndex != -1 && _eleNodes.Get(nodeIndex, _enodeIdxElt) != id)
             {
@@ -261,7 +265,7 @@ public class FloatQuadTree<T> : IDisposable
             int node = (int)toProcess.Get(toProcess.InternalCount - 1, 0);
             int fc = _nodes.Get(node, _nodeIdxFc);
             int numEmptyLeaves = 0;
-            toProcess.PopBack();
+            toProcess.InternalCount--;
 
             // Loop through the children.
             for (int j = 0; j < 4; ++j)
@@ -317,7 +321,7 @@ public class FloatQuadTree<T> : IDisposable
         ReadOnlySpan<float> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<float>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<float>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -325,12 +329,10 @@ public class FloatQuadTree<T> : IDisposable
             _temp = new bool[_tempSize];
         }
 
-        int ndIndex;
-
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             while (eltNodeIndex != -1)
@@ -377,7 +379,7 @@ public class FloatQuadTree<T> : IDisposable
         ReadOnlySpan<float> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<float>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<float>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -386,11 +388,11 @@ public class FloatQuadTree<T> : IDisposable
         }
 
         bool cancel = false;
-        int ndIndex;
+
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -400,7 +402,7 @@ public class FloatQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                     intListOut.Set(intListOut.PushBack(), 0, element);
                     _temp![element] = true;
@@ -408,7 +410,7 @@ public class FloatQuadTree<T> : IDisposable
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -441,14 +443,13 @@ public class FloatQuadTree<T> : IDisposable
     {
         ReadOnlySpan<float> bounds = stackalloc[] { x1, y1, x2, y2 };
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<float>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<float>(_rootNode), bounds);
 
         bool cancel = false;
-        int ndIndex;
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -459,13 +460,13 @@ public class FloatQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                 }
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -509,52 +510,104 @@ public class FloatQuadTree<T> : IDisposable
     {
         nodes.PushBack(stackalloc[] { ndMx, ndMy, ndSx, ndSy, ndIndex, ndDepth });
     }
-    private FloatList.Cache.Item find_leaves(
+    private FloatList.Cache.Item FindLeaves(
         ReadOnlySpan<float> data,
         ReadOnlySpan<float> bounds)
     {
         var leaves = _listCache.Get();
         var toProcess = _listCache.Get();
-        toProcess.List.PushBack(data);
+        var toProcessList = toProcess.List;
+        var toProcessListData = toProcessList.Data!;
 
-        while (toProcess.List.InternalCount > 0)
+        toProcessList.PushBack(data);
+
+        while (toProcessList.InternalCount > 0)
         {
-            int backIdx = toProcess.List.InternalCount - 1;
-            var ndData = toProcess.List.Get(backIdx, 0, 6);
+            int backIdx = toProcessList.InternalCount - 1;
+            int backOffset = backIdx * 6;
+            //var ndData = toProcessList.Get(backIdx, 0, 6);
+            //var ndIndex = (int)ndData[_ndIdxIndex];
+            //var ndDepth = (int)ndData[_ndIdxDepth];
 
-            var ndIndex = (int)ndData[_ndIdxIndex];
-            var ndDepth = (int)ndData[_ndIdxDepth];
-            toProcess.List.PopBack();
+            var ndIndexOffset = (int)toProcessListData[backOffset + _ndIdxIndex] * 2;
+            var ndDepth = (int)toProcessListData[backOffset + _ndIdxDepth];
+            toProcessList.InternalCount--;
 
             // If this node is a leaf, insert it to the list.
-            if (_nodes.Get(ndIndex, _nodeIdxNum) != -1)
-                leaves.List.PushBack(ndData);
+            
+            if (_nodes.Data![ndIndexOffset + _nodeIdxNum] != -1)
+            {
+                leaves.List.PushBack(toProcessList.Get(backIdx, 0, 6));
+            }
             else
             {
+                var mx = toProcessListData[backOffset + _ndIdxMx];
+                var my = toProcessListData[backOffset + _ndIdxMy];
                 // Otherwise push the children that intersect the rectangle.
-                int fc = _nodes.Get(ndIndex, _nodeIdxFc);
-                var hx = ndData[_ndIdxSx] / 2;
-                var hy = ndData[_ndIdxSy] / 2;
-                var l = ndData[_ndIdxMx] - hx;
-                var t = ndData[_ndIdxMy] - hx;
-                var r = ndData[_ndIdxMx] + hx;
-                var b = ndData[_ndIdxMy] + hy;
+                int fc = _nodes.Data[ndIndexOffset + _nodeIdxFc]; //_nodes.Get(ndIndex, _nodeIdxFc);
+                var hx = toProcessListData[backOffset + _ndIdxSx] / 2;
+                var hy = toProcessListData[backOffset + _ndIdxSy] / 2;
+                var l = mx - hx;
+                var r = mx + hx;
 
-                if (bounds[_eltIdxTop] <= ndData[_ndIdxMy])
+                var offset = toProcessList.InternalCount;
+                toProcessList.EnsureSpaceAvailable(4);
+
+                if (bounds[_eltIdxTop] <= my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 0, ndDepth + 1, l, t, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 1, ndDepth + 1, r, t, hx, hy);
+                    var t = my - hx;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 0; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                        //toProcessList.PushBack(processItem);
+                        //toProcessList.PushBack(stackalloc[] { l, t, hx, hy, fc + 0, ndDepth + 1 });
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 1; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
 
-                if (bounds[_eltIdxBtm] > ndData[_ndIdxMy])
+                if (bounds[_eltIdxBtm] > my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 2, ndDepth + 1, l, b, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 3, ndDepth + 1, r, b, hx, hy);
+                    var b = my + hy;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 2; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 3; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
+
+                toProcessList.InternalCount = offset;
             }
         }
 
@@ -563,9 +616,9 @@ public class FloatQuadTree<T> : IDisposable
         return leaves;
     }
 
-    private void node_insert(ReadOnlySpan<float> data, ReadOnlySpan<float> elementBounds, int elementId)
+    private void NodeInsert(ReadOnlySpan<float> data, ReadOnlySpan<float> elementBounds, int elementId)
     {
-        var leaves = find_leaves(data, elementBounds);
+        var leaves = FindLeaves(data, elementBounds);
 
         for (int j = 0; j < leaves.List.InternalCount; ++j)
             leaf_insert(elementId, leaves.List.Get(j, 0, 6));
@@ -589,7 +642,7 @@ public class FloatQuadTree<T> : IDisposable
         if (_nodes.Get(node, _nodeIdxNum) == _maxElements && depth < _maxDepth)
         {
             // Transfer elements from the leaf node to a list of elements.
-            IntList elts = new IntList(1);
+            IntList elements = new IntList(1);
             while (_nodes.Get(node, _nodeIdxFc) != -1)
             {
                 int index = _nodes.Get(node, _nodeIdxFc);
@@ -601,29 +654,19 @@ public class FloatQuadTree<T> : IDisposable
                 _eleNodes.Erase(index);
 
                 // Insert element to the list.
-                elts.Set(elts.PushBack(), 0, elt);
+                elements.Set(elements.PushBack(), 0, elt);
             }
 
             // Start by allocating 4 child nodes.
-            int fc = _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
+            int fc = _nodes.PushBackCount(_defaultNode4Values, 4);
             _nodes.Set(node, _nodeIdxFc, fc);
-
-            // Initialize the new child nodes.
-            for (int j = 0; j < 4; ++j)
-            {
-                _nodes.Set(fc + j, _nodeIdxFc, -1);
-                _nodes.Set(fc + j, _nodeIdxNum, 0);
-            }
 
             // Transfer the elements in the former leaf node to its new children.
             _nodes.Set(node, _nodeIdxNum, -1);
-            for (int j = 0; j < elts.InternalCount; ++j)
+            for (int j = 0; j < elements.InternalCount; ++j)
             {
-                var id = elts.GetInt(j, 0);
-                node_insert(data, _eleBounds.Get(id, 0, 4), id);
+                var id = elements.GetInt(j, 0);
+                NodeInsert(data, _eleBounds.Get(id, 0, 4), id);
             }
         }
         else
@@ -694,7 +737,14 @@ public class LongQuadTree<T> : IDisposable
     const int _nodeIdxFc = 0;
 
     // Stores the number of elements in the node or -1 if it is not a leaf.
-    static int _nodeIdxNum = 1;
+    const int _nodeIdxNum = 1;
+
+    /// <summary>
+    /// A static array of integers used as the default values for new child nodes in the quadtree. 
+    /// These values are used when a leaf node in the quadtree is full and needs to be split into four child nodes.
+    /// Each pair of -1 and 0 in the array represents the initial state of a child node, where -1 indicates that the node is empty and 0 indicates that the node has no elements.
+    /// </summary>
+    private static readonly int[] _defaultNode4Values = new[] { -1, 0, -1, 0, -1, 0, -1, 0, };
 
     // Stores all the nodes in the quadtree. The first node in this
     // sequence is always the root.
@@ -799,7 +849,7 @@ public class LongQuadTree<T> : IDisposable
 
         if (property == null)
             throw new Exception(
-                $"Type {typeof(T).FullName} does not contain a interger property named QuadTreeId as required.");
+                $"Type {typeof(T).FullName} does not contain a integer property named QuadTreeId as required.");
 
         _quadTreeIdSetter = property.GetBackingField().CreateSetter<T, int>();
     }
@@ -828,7 +878,7 @@ public class LongQuadTree<T> : IDisposable
         items[newElement] = element;
 
         // Insert the element to the appropriate leaf node(s).
-        node_insert(new ReadOnlySpan<long>(_rootNode), bounds, newElement);
+        NodeInsert(new ReadOnlySpan<long>(_rootNode), bounds, newElement);
          _quadTreeIdSetter(element, newElement);
         return newElement;
     }
@@ -841,20 +891,17 @@ public class LongQuadTree<T> : IDisposable
     {
         var id = element.QuadTreeId;
         // Find the leaves.
-        var leaves = find_leaves(
+        var leaves = FindLeaves(
             new ReadOnlySpan<long>(_rootNode),
             _eleBounds.Get(id, 0, 4));
-
-        int nodeIndex;
-        int ndIndex;
 
         // For each leaf node, remove the element node.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list until we find the element node.
-            nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
+            var nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             int prevIndex = -1;
             while (nodeIndex != -1 && _eleNodes.Get(nodeIndex, _enodeIdxElt) != id)
             {
@@ -903,7 +950,7 @@ public class LongQuadTree<T> : IDisposable
             int node = (int)toProcess.Get(toProcess.InternalCount - 1, 0);
             int fc = _nodes.Get(node, _nodeIdxFc);
             int numEmptyLeaves = 0;
-            toProcess.PopBack();
+            toProcess.InternalCount--;
 
             // Loop through the children.
             for (int j = 0; j < 4; ++j)
@@ -959,7 +1006,7 @@ public class LongQuadTree<T> : IDisposable
         ReadOnlySpan<long> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<long>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<long>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -967,12 +1014,10 @@ public class LongQuadTree<T> : IDisposable
             _temp = new bool[_tempSize];
         }
 
-        int ndIndex;
-
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             while (eltNodeIndex != -1)
@@ -1019,7 +1064,7 @@ public class LongQuadTree<T> : IDisposable
         ReadOnlySpan<long> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<long>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<long>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -1028,11 +1073,11 @@ public class LongQuadTree<T> : IDisposable
         }
 
         bool cancel = false;
-        int ndIndex;
+
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -1042,7 +1087,7 @@ public class LongQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                     intListOut.Set(intListOut.PushBack(), 0, element);
                     _temp![element] = true;
@@ -1050,7 +1095,7 @@ public class LongQuadTree<T> : IDisposable
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -1083,14 +1128,13 @@ public class LongQuadTree<T> : IDisposable
     {
         ReadOnlySpan<long> bounds = stackalloc[] { x1, y1, x2, y2 };
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<long>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<long>(_rootNode), bounds);
 
         bool cancel = false;
-        int ndIndex;
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -1101,13 +1145,13 @@ public class LongQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                 }
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -1151,52 +1195,104 @@ public class LongQuadTree<T> : IDisposable
     {
         nodes.PushBack(stackalloc[] { ndMx, ndMy, ndSx, ndSy, ndIndex, ndDepth });
     }
-    private LongList.Cache.Item find_leaves(
+    private LongList.Cache.Item FindLeaves(
         ReadOnlySpan<long> data,
         ReadOnlySpan<long> bounds)
     {
         var leaves = _listCache.Get();
         var toProcess = _listCache.Get();
-        toProcess.List.PushBack(data);
+        var toProcessList = toProcess.List;
+        var toProcessListData = toProcessList.Data!;
 
-        while (toProcess.List.InternalCount > 0)
+        toProcessList.PushBack(data);
+
+        while (toProcessList.InternalCount > 0)
         {
-            int backIdx = toProcess.List.InternalCount - 1;
-            var ndData = toProcess.List.Get(backIdx, 0, 6);
+            int backIdx = toProcessList.InternalCount - 1;
+            int backOffset = backIdx * 6;
+            //var ndData = toProcessList.Get(backIdx, 0, 6);
+            //var ndIndex = (int)ndData[_ndIdxIndex];
+            //var ndDepth = (int)ndData[_ndIdxDepth];
 
-            var ndIndex = (int)ndData[_ndIdxIndex];
-            var ndDepth = (int)ndData[_ndIdxDepth];
-            toProcess.List.PopBack();
+            var ndIndexOffset = (int)toProcessListData[backOffset + _ndIdxIndex] * 2;
+            var ndDepth = (int)toProcessListData[backOffset + _ndIdxDepth];
+            toProcessList.InternalCount--;
 
             // If this node is a leaf, insert it to the list.
-            if (_nodes.Get(ndIndex, _nodeIdxNum) != -1)
-                leaves.List.PushBack(ndData);
+            
+            if (_nodes.Data![ndIndexOffset + _nodeIdxNum] != -1)
+            {
+                leaves.List.PushBack(toProcessList.Get(backIdx, 0, 6));
+            }
             else
             {
+                var mx = toProcessListData[backOffset + _ndIdxMx];
+                var my = toProcessListData[backOffset + _ndIdxMy];
                 // Otherwise push the children that intersect the rectangle.
-                int fc = _nodes.Get(ndIndex, _nodeIdxFc);
-                var hx = ndData[_ndIdxSx] / 2;
-                var hy = ndData[_ndIdxSy] / 2;
-                var l = ndData[_ndIdxMx] - hx;
-                var t = ndData[_ndIdxMy] - hx;
-                var r = ndData[_ndIdxMx] + hx;
-                var b = ndData[_ndIdxMy] + hy;
+                int fc = _nodes.Data[ndIndexOffset + _nodeIdxFc]; //_nodes.Get(ndIndex, _nodeIdxFc);
+                var hx = toProcessListData[backOffset + _ndIdxSx] / 2;
+                var hy = toProcessListData[backOffset + _ndIdxSy] / 2;
+                var l = mx - hx;
+                var r = mx + hx;
 
-                if (bounds[_eltIdxTop] <= ndData[_ndIdxMy])
+                var offset = toProcessList.InternalCount;
+                toProcessList.EnsureSpaceAvailable(4);
+
+                if (bounds[_eltIdxTop] <= my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 0, ndDepth + 1, l, t, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 1, ndDepth + 1, r, t, hx, hy);
+                    var t = my - hx;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 0; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                        //toProcessList.PushBack(processItem);
+                        //toProcessList.PushBack(stackalloc[] { l, t, hx, hy, fc + 0, ndDepth + 1 });
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 1; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
 
-                if (bounds[_eltIdxBtm] > ndData[_ndIdxMy])
+                if (bounds[_eltIdxBtm] > my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 2, ndDepth + 1, l, b, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 3, ndDepth + 1, r, b, hx, hy);
+                    var b = my + hy;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 2; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 3; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
+
+                toProcessList.InternalCount = offset;
             }
         }
 
@@ -1205,9 +1301,9 @@ public class LongQuadTree<T> : IDisposable
         return leaves;
     }
 
-    private void node_insert(ReadOnlySpan<long> data, ReadOnlySpan<long> elementBounds, int elementId)
+    private void NodeInsert(ReadOnlySpan<long> data, ReadOnlySpan<long> elementBounds, int elementId)
     {
-        var leaves = find_leaves(data, elementBounds);
+        var leaves = FindLeaves(data, elementBounds);
 
         for (int j = 0; j < leaves.List.InternalCount; ++j)
             leaf_insert(elementId, leaves.List.Get(j, 0, 6));
@@ -1231,7 +1327,7 @@ public class LongQuadTree<T> : IDisposable
         if (_nodes.Get(node, _nodeIdxNum) == _maxElements && depth < _maxDepth)
         {
             // Transfer elements from the leaf node to a list of elements.
-            IntList elts = new IntList(1);
+            IntList elements = new IntList(1);
             while (_nodes.Get(node, _nodeIdxFc) != -1)
             {
                 int index = _nodes.Get(node, _nodeIdxFc);
@@ -1243,29 +1339,19 @@ public class LongQuadTree<T> : IDisposable
                 _eleNodes.Erase(index);
 
                 // Insert element to the list.
-                elts.Set(elts.PushBack(), 0, elt);
+                elements.Set(elements.PushBack(), 0, elt);
             }
 
             // Start by allocating 4 child nodes.
-            int fc = _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
+            int fc = _nodes.PushBackCount(_defaultNode4Values, 4);
             _nodes.Set(node, _nodeIdxFc, fc);
-
-            // Initialize the new child nodes.
-            for (int j = 0; j < 4; ++j)
-            {
-                _nodes.Set(fc + j, _nodeIdxFc, -1);
-                _nodes.Set(fc + j, _nodeIdxNum, 0);
-            }
 
             // Transfer the elements in the former leaf node to its new children.
             _nodes.Set(node, _nodeIdxNum, -1);
-            for (int j = 0; j < elts.InternalCount; ++j)
+            for (int j = 0; j < elements.InternalCount; ++j)
             {
-                var id = elts.GetInt(j, 0);
-                node_insert(data, _eleBounds.Get(id, 0, 4), id);
+                var id = elements.GetInt(j, 0);
+                NodeInsert(data, _eleBounds.Get(id, 0, 4), id);
             }
         }
         else
@@ -1336,7 +1422,14 @@ public class IntQuadTree<T> : IDisposable
     const int _nodeIdxFc = 0;
 
     // Stores the number of elements in the node or -1 if it is not a leaf.
-    static int _nodeIdxNum = 1;
+    const int _nodeIdxNum = 1;
+
+    /// <summary>
+    /// A static array of integers used as the default values for new child nodes in the quadtree. 
+    /// These values are used when a leaf node in the quadtree is full and needs to be split into four child nodes.
+    /// Each pair of -1 and 0 in the array represents the initial state of a child node, where -1 indicates that the node is empty and 0 indicates that the node has no elements.
+    /// </summary>
+    private static readonly int[] _defaultNode4Values = new[] { -1, 0, -1, 0, -1, 0, -1, 0, };
 
     // Stores all the nodes in the quadtree. The first node in this
     // sequence is always the root.
@@ -1441,7 +1534,7 @@ public class IntQuadTree<T> : IDisposable
 
         if (property == null)
             throw new Exception(
-                $"Type {typeof(T).FullName} does not contain a interger property named QuadTreeId as required.");
+                $"Type {typeof(T).FullName} does not contain a integer property named QuadTreeId as required.");
 
         _quadTreeIdSetter = property.GetBackingField().CreateSetter<T, int>();
     }
@@ -1470,7 +1563,7 @@ public class IntQuadTree<T> : IDisposable
         items[newElement] = element;
 
         // Insert the element to the appropriate leaf node(s).
-        node_insert(new ReadOnlySpan<int>(_rootNode), bounds, newElement);
+        NodeInsert(new ReadOnlySpan<int>(_rootNode), bounds, newElement);
          _quadTreeIdSetter(element, newElement);
         return newElement;
     }
@@ -1483,20 +1576,17 @@ public class IntQuadTree<T> : IDisposable
     {
         var id = element.QuadTreeId;
         // Find the leaves.
-        var leaves = find_leaves(
+        var leaves = FindLeaves(
             new ReadOnlySpan<int>(_rootNode),
             _eleBounds.Get(id, 0, 4));
-
-        int nodeIndex;
-        int ndIndex;
 
         // For each leaf node, remove the element node.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list until we find the element node.
-            nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
+            var nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             int prevIndex = -1;
             while (nodeIndex != -1 && _eleNodes.Get(nodeIndex, _enodeIdxElt) != id)
             {
@@ -1545,7 +1635,7 @@ public class IntQuadTree<T> : IDisposable
             int node = (int)toProcess.Get(toProcess.InternalCount - 1, 0);
             int fc = _nodes.Get(node, _nodeIdxFc);
             int numEmptyLeaves = 0;
-            toProcess.PopBack();
+            toProcess.InternalCount--;
 
             // Loop through the children.
             for (int j = 0; j < 4; ++j)
@@ -1601,7 +1691,7 @@ public class IntQuadTree<T> : IDisposable
         ReadOnlySpan<int> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<int>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<int>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -1609,12 +1699,10 @@ public class IntQuadTree<T> : IDisposable
             _temp = new bool[_tempSize];
         }
 
-        int ndIndex;
-
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             while (eltNodeIndex != -1)
@@ -1661,7 +1749,7 @@ public class IntQuadTree<T> : IDisposable
         ReadOnlySpan<int> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<int>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<int>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -1670,11 +1758,11 @@ public class IntQuadTree<T> : IDisposable
         }
 
         bool cancel = false;
-        int ndIndex;
+
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -1684,7 +1772,7 @@ public class IntQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                     intListOut.Set(intListOut.PushBack(), 0, element);
                     _temp![element] = true;
@@ -1692,7 +1780,7 @@ public class IntQuadTree<T> : IDisposable
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -1725,14 +1813,13 @@ public class IntQuadTree<T> : IDisposable
     {
         ReadOnlySpan<int> bounds = stackalloc[] { x1, y1, x2, y2 };
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<int>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<int>(_rootNode), bounds);
 
         bool cancel = false;
-        int ndIndex;
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -1743,13 +1830,13 @@ public class IntQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                 }
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -1793,52 +1880,104 @@ public class IntQuadTree<T> : IDisposable
     {
         nodes.PushBack(stackalloc[] { ndMx, ndMy, ndSx, ndSy, ndIndex, ndDepth });
     }
-    private IntList.Cache.Item find_leaves(
+    private IntList.Cache.Item FindLeaves(
         ReadOnlySpan<int> data,
         ReadOnlySpan<int> bounds)
     {
         var leaves = _listCache.Get();
         var toProcess = _listCache.Get();
-        toProcess.List.PushBack(data);
+        var toProcessList = toProcess.List;
+        var toProcessListData = toProcessList.Data!;
 
-        while (toProcess.List.InternalCount > 0)
+        toProcessList.PushBack(data);
+
+        while (toProcessList.InternalCount > 0)
         {
-            int backIdx = toProcess.List.InternalCount - 1;
-            var ndData = toProcess.List.Get(backIdx, 0, 6);
+            int backIdx = toProcessList.InternalCount - 1;
+            int backOffset = backIdx * 6;
+            //var ndData = toProcessList.Get(backIdx, 0, 6);
+            //var ndIndex = (int)ndData[_ndIdxIndex];
+            //var ndDepth = (int)ndData[_ndIdxDepth];
 
-            var ndIndex = (int)ndData[_ndIdxIndex];
-            var ndDepth = (int)ndData[_ndIdxDepth];
-            toProcess.List.PopBack();
+            var ndIndexOffset = (int)toProcessListData[backOffset + _ndIdxIndex] * 2;
+            var ndDepth = (int)toProcessListData[backOffset + _ndIdxDepth];
+            toProcessList.InternalCount--;
 
             // If this node is a leaf, insert it to the list.
-            if (_nodes.Get(ndIndex, _nodeIdxNum) != -1)
-                leaves.List.PushBack(ndData);
+            
+            if (_nodes.Data![ndIndexOffset + _nodeIdxNum] != -1)
+            {
+                leaves.List.PushBack(toProcessList.Get(backIdx, 0, 6));
+            }
             else
             {
+                var mx = toProcessListData[backOffset + _ndIdxMx];
+                var my = toProcessListData[backOffset + _ndIdxMy];
                 // Otherwise push the children that intersect the rectangle.
-                int fc = _nodes.Get(ndIndex, _nodeIdxFc);
-                var hx = ndData[_ndIdxSx] / 2;
-                var hy = ndData[_ndIdxSy] / 2;
-                var l = ndData[_ndIdxMx] - hx;
-                var t = ndData[_ndIdxMy] - hx;
-                var r = ndData[_ndIdxMx] + hx;
-                var b = ndData[_ndIdxMy] + hy;
+                int fc = _nodes.Data[ndIndexOffset + _nodeIdxFc]; //_nodes.Get(ndIndex, _nodeIdxFc);
+                var hx = toProcessListData[backOffset + _ndIdxSx] / 2;
+                var hy = toProcessListData[backOffset + _ndIdxSy] / 2;
+                var l = mx - hx;
+                var r = mx + hx;
 
-                if (bounds[_eltIdxTop] <= ndData[_ndIdxMy])
+                var offset = toProcessList.InternalCount;
+                toProcessList.EnsureSpaceAvailable(4);
+
+                if (bounds[_eltIdxTop] <= my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 0, ndDepth + 1, l, t, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 1, ndDepth + 1, r, t, hx, hy);
+                    var t = my - hx;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 0; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                        //toProcessList.PushBack(processItem);
+                        //toProcessList.PushBack(stackalloc[] { l, t, hx, hy, fc + 0, ndDepth + 1 });
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 1; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
 
-                if (bounds[_eltIdxBtm] > ndData[_ndIdxMy])
+                if (bounds[_eltIdxBtm] > my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 2, ndDepth + 1, l, b, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 3, ndDepth + 1, r, b, hx, hy);
+                    var b = my + hy;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 2; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 3; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
+
+                toProcessList.InternalCount = offset;
             }
         }
 
@@ -1847,9 +1986,9 @@ public class IntQuadTree<T> : IDisposable
         return leaves;
     }
 
-    private void node_insert(ReadOnlySpan<int> data, ReadOnlySpan<int> elementBounds, int elementId)
+    private void NodeInsert(ReadOnlySpan<int> data, ReadOnlySpan<int> elementBounds, int elementId)
     {
-        var leaves = find_leaves(data, elementBounds);
+        var leaves = FindLeaves(data, elementBounds);
 
         for (int j = 0; j < leaves.List.InternalCount; ++j)
             leaf_insert(elementId, leaves.List.Get(j, 0, 6));
@@ -1873,7 +2012,7 @@ public class IntQuadTree<T> : IDisposable
         if (_nodes.Get(node, _nodeIdxNum) == _maxElements && depth < _maxDepth)
         {
             // Transfer elements from the leaf node to a list of elements.
-            IntList elts = new IntList(1);
+            IntList elements = new IntList(1);
             while (_nodes.Get(node, _nodeIdxFc) != -1)
             {
                 int index = _nodes.Get(node, _nodeIdxFc);
@@ -1885,29 +2024,19 @@ public class IntQuadTree<T> : IDisposable
                 _eleNodes.Erase(index);
 
                 // Insert element to the list.
-                elts.Set(elts.PushBack(), 0, elt);
+                elements.Set(elements.PushBack(), 0, elt);
             }
 
             // Start by allocating 4 child nodes.
-            int fc = _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
+            int fc = _nodes.PushBackCount(_defaultNode4Values, 4);
             _nodes.Set(node, _nodeIdxFc, fc);
-
-            // Initialize the new child nodes.
-            for (int j = 0; j < 4; ++j)
-            {
-                _nodes.Set(fc + j, _nodeIdxFc, -1);
-                _nodes.Set(fc + j, _nodeIdxNum, 0);
-            }
 
             // Transfer the elements in the former leaf node to its new children.
             _nodes.Set(node, _nodeIdxNum, -1);
-            for (int j = 0; j < elts.InternalCount; ++j)
+            for (int j = 0; j < elements.InternalCount; ++j)
             {
-                var id = elts.GetInt(j, 0);
-                node_insert(data, _eleBounds.Get(id, 0, 4), id);
+                var id = elements.GetInt(j, 0);
+                NodeInsert(data, _eleBounds.Get(id, 0, 4), id);
             }
         }
         else
@@ -1978,7 +2107,14 @@ public class DoubleQuadTree<T> : IDisposable
     const int _nodeIdxFc = 0;
 
     // Stores the number of elements in the node or -1 if it is not a leaf.
-    static int _nodeIdxNum = 1;
+    const int _nodeIdxNum = 1;
+
+    /// <summary>
+    /// A static array of integers used as the default values for new child nodes in the quadtree. 
+    /// These values are used when a leaf node in the quadtree is full and needs to be split into four child nodes.
+    /// Each pair of -1 and 0 in the array represents the initial state of a child node, where -1 indicates that the node is empty and 0 indicates that the node has no elements.
+    /// </summary>
+    private static readonly int[] _defaultNode4Values = new[] { -1, 0, -1, 0, -1, 0, -1, 0, };
 
     // Stores all the nodes in the quadtree. The first node in this
     // sequence is always the root.
@@ -2083,7 +2219,7 @@ public class DoubleQuadTree<T> : IDisposable
 
         if (property == null)
             throw new Exception(
-                $"Type {typeof(T).FullName} does not contain a interger property named QuadTreeId as required.");
+                $"Type {typeof(T).FullName} does not contain a integer property named QuadTreeId as required.");
 
         _quadTreeIdSetter = property.GetBackingField().CreateSetter<T, int>();
     }
@@ -2112,7 +2248,7 @@ public class DoubleQuadTree<T> : IDisposable
         items[newElement] = element;
 
         // Insert the element to the appropriate leaf node(s).
-        node_insert(new ReadOnlySpan<double>(_rootNode), bounds, newElement);
+        NodeInsert(new ReadOnlySpan<double>(_rootNode), bounds, newElement);
          _quadTreeIdSetter(element, newElement);
         return newElement;
     }
@@ -2125,20 +2261,17 @@ public class DoubleQuadTree<T> : IDisposable
     {
         var id = element.QuadTreeId;
         // Find the leaves.
-        var leaves = find_leaves(
+        var leaves = FindLeaves(
             new ReadOnlySpan<double>(_rootNode),
             _eleBounds.Get(id, 0, 4));
-
-        int nodeIndex;
-        int ndIndex;
 
         // For each leaf node, remove the element node.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list until we find the element node.
-            nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
+            var nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             int prevIndex = -1;
             while (nodeIndex != -1 && _eleNodes.Get(nodeIndex, _enodeIdxElt) != id)
             {
@@ -2187,7 +2320,7 @@ public class DoubleQuadTree<T> : IDisposable
             int node = (int)toProcess.Get(toProcess.InternalCount - 1, 0);
             int fc = _nodes.Get(node, _nodeIdxFc);
             int numEmptyLeaves = 0;
-            toProcess.PopBack();
+            toProcess.InternalCount--;
 
             // Loop through the children.
             for (int j = 0; j < 4; ++j)
@@ -2243,7 +2376,7 @@ public class DoubleQuadTree<T> : IDisposable
         ReadOnlySpan<double> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<double>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<double>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -2251,12 +2384,10 @@ public class DoubleQuadTree<T> : IDisposable
             _temp = new bool[_tempSize];
         }
 
-        int ndIndex;
-
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             while (eltNodeIndex != -1)
@@ -2303,7 +2434,7 @@ public class DoubleQuadTree<T> : IDisposable
         ReadOnlySpan<double> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<double>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<double>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -2312,11 +2443,11 @@ public class DoubleQuadTree<T> : IDisposable
         }
 
         bool cancel = false;
-        int ndIndex;
+
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -2326,7 +2457,7 @@ public class DoubleQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                     intListOut.Set(intListOut.PushBack(), 0, element);
                     _temp![element] = true;
@@ -2334,7 +2465,7 @@ public class DoubleQuadTree<T> : IDisposable
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -2367,14 +2498,13 @@ public class DoubleQuadTree<T> : IDisposable
     {
         ReadOnlySpan<double> bounds = stackalloc[] { x1, y1, x2, y2 };
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<double>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<double>(_rootNode), bounds);
 
         bool cancel = false;
-        int ndIndex;
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -2385,13 +2515,13 @@ public class DoubleQuadTree<T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                 }
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -2435,52 +2565,104 @@ public class DoubleQuadTree<T> : IDisposable
     {
         nodes.PushBack(stackalloc[] { ndMx, ndMy, ndSx, ndSy, ndIndex, ndDepth });
     }
-    private DoubleList.Cache.Item find_leaves(
+    private DoubleList.Cache.Item FindLeaves(
         ReadOnlySpan<double> data,
         ReadOnlySpan<double> bounds)
     {
         var leaves = _listCache.Get();
         var toProcess = _listCache.Get();
-        toProcess.List.PushBack(data);
+        var toProcessList = toProcess.List;
+        var toProcessListData = toProcessList.Data!;
 
-        while (toProcess.List.InternalCount > 0)
+        toProcessList.PushBack(data);
+
+        while (toProcessList.InternalCount > 0)
         {
-            int backIdx = toProcess.List.InternalCount - 1;
-            var ndData = toProcess.List.Get(backIdx, 0, 6);
+            int backIdx = toProcessList.InternalCount - 1;
+            int backOffset = backIdx * 6;
+            //var ndData = toProcessList.Get(backIdx, 0, 6);
+            //var ndIndex = (int)ndData[_ndIdxIndex];
+            //var ndDepth = (int)ndData[_ndIdxDepth];
 
-            var ndIndex = (int)ndData[_ndIdxIndex];
-            var ndDepth = (int)ndData[_ndIdxDepth];
-            toProcess.List.PopBack();
+            var ndIndexOffset = (int)toProcessListData[backOffset + _ndIdxIndex] * 2;
+            var ndDepth = (int)toProcessListData[backOffset + _ndIdxDepth];
+            toProcessList.InternalCount--;
 
             // If this node is a leaf, insert it to the list.
-            if (_nodes.Get(ndIndex, _nodeIdxNum) != -1)
-                leaves.List.PushBack(ndData);
+            
+            if (_nodes.Data![ndIndexOffset + _nodeIdxNum] != -1)
+            {
+                leaves.List.PushBack(toProcessList.Get(backIdx, 0, 6));
+            }
             else
             {
+                var mx = toProcessListData[backOffset + _ndIdxMx];
+                var my = toProcessListData[backOffset + _ndIdxMy];
                 // Otherwise push the children that intersect the rectangle.
-                int fc = _nodes.Get(ndIndex, _nodeIdxFc);
-                var hx = ndData[_ndIdxSx] / 2;
-                var hy = ndData[_ndIdxSy] / 2;
-                var l = ndData[_ndIdxMx] - hx;
-                var t = ndData[_ndIdxMy] - hx;
-                var r = ndData[_ndIdxMx] + hx;
-                var b = ndData[_ndIdxMy] + hy;
+                int fc = _nodes.Data[ndIndexOffset + _nodeIdxFc]; //_nodes.Get(ndIndex, _nodeIdxFc);
+                var hx = toProcessListData[backOffset + _ndIdxSx] / 2;
+                var hy = toProcessListData[backOffset + _ndIdxSy] / 2;
+                var l = mx - hx;
+                var r = mx + hx;
 
-                if (bounds[_eltIdxTop] <= ndData[_ndIdxMy])
+                var offset = toProcessList.InternalCount;
+                toProcessList.EnsureSpaceAvailable(4);
+
+                if (bounds[_eltIdxTop] <= my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 0, ndDepth + 1, l, t, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 1, ndDepth + 1, r, t, hx, hy);
+                    var t = my - hx;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 0; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                        //toProcessList.PushBack(processItem);
+                        //toProcessList.PushBack(stackalloc[] { l, t, hx, hy, fc + 0, ndDepth + 1 });
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 1; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
 
-                if (bounds[_eltIdxBtm] > ndData[_ndIdxMy])
+                if (bounds[_eltIdxBtm] > my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 2, ndDepth + 1, l, b, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 3, ndDepth + 1, r, b, hx, hy);
+                    var b = my + hy;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 2; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 3; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
+
+                toProcessList.InternalCount = offset;
             }
         }
 
@@ -2489,9 +2671,9 @@ public class DoubleQuadTree<T> : IDisposable
         return leaves;
     }
 
-    private void node_insert(ReadOnlySpan<double> data, ReadOnlySpan<double> elementBounds, int elementId)
+    private void NodeInsert(ReadOnlySpan<double> data, ReadOnlySpan<double> elementBounds, int elementId)
     {
-        var leaves = find_leaves(data, elementBounds);
+        var leaves = FindLeaves(data, elementBounds);
 
         for (int j = 0; j < leaves.List.InternalCount; ++j)
             leaf_insert(elementId, leaves.List.Get(j, 0, 6));
@@ -2515,7 +2697,7 @@ public class DoubleQuadTree<T> : IDisposable
         if (_nodes.Get(node, _nodeIdxNum) == _maxElements && depth < _maxDepth)
         {
             // Transfer elements from the leaf node to a list of elements.
-            IntList elts = new IntList(1);
+            IntList elements = new IntList(1);
             while (_nodes.Get(node, _nodeIdxFc) != -1)
             {
                 int index = _nodes.Get(node, _nodeIdxFc);
@@ -2527,29 +2709,19 @@ public class DoubleQuadTree<T> : IDisposable
                 _eleNodes.Erase(index);
 
                 // Insert element to the list.
-                elts.Set(elts.PushBack(), 0, elt);
+                elements.Set(elements.PushBack(), 0, elt);
             }
 
             // Start by allocating 4 child nodes.
-            int fc = _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
+            int fc = _nodes.PushBackCount(_defaultNode4Values, 4);
             _nodes.Set(node, _nodeIdxFc, fc);
-
-            // Initialize the new child nodes.
-            for (int j = 0; j < 4; ++j)
-            {
-                _nodes.Set(fc + j, _nodeIdxFc, -1);
-                _nodes.Set(fc + j, _nodeIdxNum, 0);
-            }
 
             // Transfer the elements in the former leaf node to its new children.
             _nodes.Set(node, _nodeIdxNum, -1);
-            for (int j = 0; j < elts.InternalCount; ++j)
+            for (int j = 0; j < elements.InternalCount; ++j)
             {
-                var id = elts.GetInt(j, 0);
-                node_insert(data, _eleBounds.Get(id, 0, 4), id);
+                var id = elements.GetInt(j, 0);
+                NodeInsert(data, _eleBounds.Get(id, 0, 4), id);
             }
         }
         else

--- a/src/DtronixCommon/Collections/Trees/QuadTrees.tt
+++ b/src/DtronixCommon/Collections/Trees/QuadTrees.tt
@@ -90,7 +90,14 @@ public class <#=config.ClassName#><T> : IDisposable
     const int _nodeIdxFc = 0;
 
     // Stores the number of elements in the node or -1 if it is not a leaf.
-    static int _nodeIdxNum = 1;
+    const int _nodeIdxNum = 1;
+
+    /// <summary>
+    /// A static array of integers used as the default values for new child nodes in the quadtree. 
+    /// These values are used when a leaf node in the quadtree is full and needs to be split into four child nodes.
+    /// Each pair of -1 and 0 in the array represents the initial state of a child node, where -1 indicates that the node is empty and 0 indicates that the node has no elements.
+    /// </summary>
+    private static readonly int[] _defaultNode4Values = new[] { -1, 0, -1, 0, -1, 0, -1, 0, };
 
     // Stores all the nodes in the quadtree. The first node in this
     // sequence is always the root.
@@ -195,7 +202,7 @@ public class <#=config.ClassName#><T> : IDisposable
 
         if (property == null)
             throw new Exception(
-                $"Type {typeof(T).FullName} does not contain a interger property named QuadTreeId as required.");
+                $"Type {typeof(T).FullName} does not contain a integer property named QuadTreeId as required.");
 
         _quadTreeIdSetter = property.GetBackingField().CreateSetter<T, int>();
     }
@@ -224,7 +231,7 @@ public class <#=config.ClassName#><T> : IDisposable
         items[newElement] = element;
 
         // Insert the element to the appropriate leaf node(s).
-        node_insert(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds, newElement);
+        NodeInsert(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds, newElement);
          _quadTreeIdSetter(element, newElement);
         return newElement;
     }
@@ -237,20 +244,17 @@ public class <#=config.ClassName#><T> : IDisposable
     {
         var id = element.QuadTreeId;
         // Find the leaves.
-        var leaves = find_leaves(
+        var leaves = FindLeaves(
             new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode),
             _eleBounds.Get(id, 0, 4));
-
-        int nodeIndex;
-        int ndIndex;
 
         // For each leaf node, remove the element node.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list until we find the element node.
-            nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
+            var nodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             int prevIndex = -1;
             while (nodeIndex != -1 && _eleNodes.Get(nodeIndex, _enodeIdxElt) != id)
             {
@@ -299,7 +303,7 @@ public class <#=config.ClassName#><T> : IDisposable
             int node = (int)toProcess.Get(toProcess.InternalCount - 1, 0);
             int fc = _nodes.Get(node, _nodeIdxFc);
             int numEmptyLeaves = 0;
-            toProcess.PopBack();
+            toProcess.InternalCount--;
 
             // Loop through the children.
             for (int j = 0; j < 4; ++j)
@@ -355,7 +359,7 @@ public class <#=config.ClassName#><T> : IDisposable
         ReadOnlySpan<<#=config.MainNumberType#>> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -363,12 +367,10 @@ public class <#=config.ClassName#><T> : IDisposable
             _temp = new bool[_tempSize];
         }
 
-        int ndIndex;
-
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
             while (eltNodeIndex != -1)
@@ -415,7 +417,7 @@ public class <#=config.ClassName#><T> : IDisposable
         ReadOnlySpan<<#=config.MainNumberType#>> bounds = stackalloc[] { x1, y1, x2, y2 };
 
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds);
 
         if (_tempSize < _eleBounds.InternalCount)
         {
@@ -424,11 +426,11 @@ public class <#=config.ClassName#><T> : IDisposable
         }
 
         bool cancel = false;
-        int ndIndex;
+
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -438,7 +440,7 @@ public class <#=config.ClassName#><T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                     intListOut.Set(intListOut.PushBack(), 0, element);
                     _temp![element] = true;
@@ -446,7 +448,7 @@ public class <#=config.ClassName#><T> : IDisposable
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -479,14 +481,13 @@ public class <#=config.ClassName#><T> : IDisposable
     {
         ReadOnlySpan<<#=config.MainNumberType#>> bounds = stackalloc[] { x1, y1, x2, y2 };
         // Find the leaves that intersect the specified query rectangle.
-        var leaves = find_leaves(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds);
+        var leaves = FindLeaves(new ReadOnlySpan<<#=config.MainNumberType#>>(_rootNode), bounds);
 
         bool cancel = false;
-        int ndIndex;
         // For each leaf node, look for elements that intersect.
         for (int j = 0; j < leaves.List.InternalCount; ++j)
         {
-            ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
+            var ndIndex = leaves.List.GetInt(j, _ndIdxIndex);
 
             // Walk the list and add elements that intersect.
             int eltNodeIndex = _nodes.Get(ndIndex, _nodeIdxFc);
@@ -497,13 +498,13 @@ public class <#=config.ClassName#><T> : IDisposable
                 if (Intersect(bounds, _eleBounds.Get(element, 0, 4)))
                 {
                     cancel = !callback.Invoke(items![element]);
-                    if(cancel)
+                    if (cancel)
                         break;
                 }
                 eltNodeIndex = _eleNodes.Get(eltNodeIndex, _enodeIdxNext);
             }
 
-            if(cancel)
+            if (cancel)
                 break;
         }
 
@@ -547,52 +548,104 @@ public class <#=config.ClassName#><T> : IDisposable
     {
         nodes.PushBack(stackalloc[] { ndMx, ndMy, ndSx, ndSy, ndIndex, ndDepth });
     }
-    private <#=config.MainListClass#>.Cache.Item find_leaves(
+    private <#=config.MainListClass#>.Cache.Item FindLeaves(
         ReadOnlySpan<<#=config.MainNumberType#>> data,
         ReadOnlySpan<<#=config.MainNumberType#>> bounds)
     {
         var leaves = _listCache.Get();
         var toProcess = _listCache.Get();
-        toProcess.List.PushBack(data);
+        var toProcessList = toProcess.List;
+        var toProcessListData = toProcessList.Data!;
 
-        while (toProcess.List.InternalCount > 0)
+        toProcessList.PushBack(data);
+
+        while (toProcessList.InternalCount > 0)
         {
-            int backIdx = toProcess.List.InternalCount - 1;
-            var ndData = toProcess.List.Get(backIdx, 0, 6);
+            int backIdx = toProcessList.InternalCount - 1;
+            int backOffset = backIdx * 6;
+            //var ndData = toProcessList.Get(backIdx, 0, 6);
+            //var ndIndex = (int)ndData[_ndIdxIndex];
+            //var ndDepth = (int)ndData[_ndIdxDepth];
 
-            var ndIndex = (int)ndData[_ndIdxIndex];
-            var ndDepth = (int)ndData[_ndIdxDepth];
-            toProcess.List.PopBack();
+            var ndIndexOffset = (int)toProcessListData[backOffset + _ndIdxIndex] * 2;
+            var ndDepth = (int)toProcessListData[backOffset + _ndIdxDepth];
+            toProcessList.InternalCount--;
 
             // If this node is a leaf, insert it to the list.
-            if (_nodes.Get(ndIndex, _nodeIdxNum) != -1)
-                leaves.List.PushBack(ndData);
+            
+            if (_nodes.Data![ndIndexOffset + _nodeIdxNum] != -1)
+            {
+                leaves.List.PushBack(toProcessList.Get(backIdx, 0, 6));
+            }
             else
             {
+                var mx = toProcessListData[backOffset + _ndIdxMx];
+                var my = toProcessListData[backOffset + _ndIdxMy];
                 // Otherwise push the children that intersect the rectangle.
-                int fc = _nodes.Get(ndIndex, _nodeIdxFc);
-                var hx = ndData[_ndIdxSx] / 2;
-                var hy = ndData[_ndIdxSy] / 2;
-                var l = ndData[_ndIdxMx] - hx;
-                var t = ndData[_ndIdxMy] - hx;
-                var r = ndData[_ndIdxMx] + hx;
-                var b = ndData[_ndIdxMy] + hy;
+                int fc = _nodes.Data[ndIndexOffset + _nodeIdxFc]; //_nodes.Get(ndIndex, _nodeIdxFc);
+                var hx = toProcessListData[backOffset + _ndIdxSx] / 2;
+                var hy = toProcessListData[backOffset + _ndIdxSy] / 2;
+                var l = mx - hx;
+                var r = mx + hx;
 
-                if (bounds[_eltIdxTop] <= ndData[_ndIdxMy])
+                var offset = toProcessList.InternalCount;
+                toProcessList.EnsureSpaceAvailable(4);
+
+                if (bounds[_eltIdxTop] <= my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 0, ndDepth + 1, l, t, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 1, ndDepth + 1, r, t, hx, hy);
+                    var t = my - hx;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 0; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                        //toProcessList.PushBack(processItem);
+                        //toProcessList.PushBack(stackalloc[] { l, t, hx, hy, fc + 0, ndDepth + 1 });
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = t; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 1; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
 
-                if (bounds[_eltIdxBtm] > ndData[_ndIdxMy])
+                if (bounds[_eltIdxBtm] > my)
                 {
-                    if (bounds[_eltIdxLft] <= ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 2, ndDepth + 1, l, b, hx, hy);
-                    if (bounds[_eltIdxRgt] > ndData[_ndIdxMx])
-                        PushNode(toProcess.List, fc + 3, ndDepth + 1, r, b, hx, hy);
+                    var b = my + hy;
+                    if (bounds[_eltIdxLft] <= mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = l; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 2; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
+
+                    if (bounds[_eltIdxRgt] > mx)
+                    {
+                        var thisOffset = offset++ * 6;
+                        toProcessListData[thisOffset + _ndIdxMx] = r; // ndMx
+                        toProcessListData[thisOffset + _ndIdxMy] = b; // ndMy
+                        toProcessListData[thisOffset + _ndIdxSx] = hx; // ndSx
+                        toProcessListData[thisOffset + _ndIdxSy] = hy; // ndSy
+                        toProcessListData[thisOffset + _ndIdxIndex] = fc + 3; // ndIndex
+                        toProcessListData[thisOffset + _ndIdxDepth] = ndDepth + 1; // ndDepth
+                    }
                 }
+
+                toProcessList.InternalCount = offset;
             }
         }
 
@@ -601,9 +654,9 @@ public class <#=config.ClassName#><T> : IDisposable
         return leaves;
     }
 
-    private void node_insert(ReadOnlySpan<<#=config.MainNumberType#>> data, ReadOnlySpan<<#=config.MainNumberType#>> elementBounds, int elementId)
+    private void NodeInsert(ReadOnlySpan<<#=config.MainNumberType#>> data, ReadOnlySpan<<#=config.MainNumberType#>> elementBounds, int elementId)
     {
-        var leaves = find_leaves(data, elementBounds);
+        var leaves = FindLeaves(data, elementBounds);
 
         for (int j = 0; j < leaves.List.InternalCount; ++j)
             leaf_insert(elementId, leaves.List.Get(j, 0, 6));
@@ -627,7 +680,7 @@ public class <#=config.ClassName#><T> : IDisposable
         if (_nodes.Get(node, _nodeIdxNum) == _maxElements && depth < _maxDepth)
         {
             // Transfer elements from the leaf node to a list of elements.
-            IntList elts = new IntList(1);
+            IntList elements = new IntList(1);
             while (_nodes.Get(node, _nodeIdxFc) != -1)
             {
                 int index = _nodes.Get(node, _nodeIdxFc);
@@ -639,29 +692,19 @@ public class <#=config.ClassName#><T> : IDisposable
                 _eleNodes.Erase(index);
 
                 // Insert element to the list.
-                elts.Set(elts.PushBack(), 0, elt);
+                elements.Set(elements.PushBack(), 0, elt);
             }
 
             // Start by allocating 4 child nodes.
-            int fc = _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
-            _nodes.Insert();
+            int fc = _nodes.PushBackCount(_defaultNode4Values, 4);
             _nodes.Set(node, _nodeIdxFc, fc);
-
-            // Initialize the new child nodes.
-            for (int j = 0; j < 4; ++j)
-            {
-                _nodes.Set(fc + j, _nodeIdxFc, -1);
-                _nodes.Set(fc + j, _nodeIdxNum, 0);
-            }
 
             // Transfer the elements in the former leaf node to its new children.
             _nodes.Set(node, _nodeIdxNum, -1);
-            for (int j = 0; j < elts.InternalCount; ++j)
+            for (int j = 0; j < elements.InternalCount; ++j)
             {
-                var id = elts.GetInt(j, 0);
-                node_insert(data, _eleBounds.Get(id, 0, 4), id);
+                var id = elements.GetInt(j, 0);
+                NodeInsert(data, _eleBounds.Get(id, 0, 4), id);
             }
         }
         else

--- a/src/DtronixCommon/DtronixCommon.csproj
+++ b/src/DtronixCommon/DtronixCommon.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net5.0;net6.0;net8.0;</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>0.8.0.0</Version>
+		<Version>0.9.0.0</Version>
 		<Nullable>enable</Nullable>
 		<LangVersion>10</LangVersion>
 		<Company>Dtronix</Company>

--- a/src/DtronixCommon/DtronixCommon.csproj
+++ b/src/DtronixCommon/DtronixCommon.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net6.0;net8.0;</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Version>0.8.0.0</Version>
 		<Nullable>enable</Nullable>
@@ -31,7 +31,7 @@
 		<TextTemplate Include="**\*.tt" />
 		<Generated Include="**\*.g.cs" />
 	</ItemGroup>
-	<Target Name="TextTemplateTransform" BeforeTargets="CoreCompile" DependsOnTargets="PrepareForBuild">
+	<Target Name="TextTemplateTransform" BeforeTargets="BeforeBuild">
 		<Exec WorkingDirectory="$(ProjectDir)" Command="dotnet t4 %(TextTemplate.Identity)" />
 	</Target>
 	<Target Name="TextTemplateClean" AfterTargets="Clean">

--- a/src/DtronixCommonBenchmarks/Collections/Trees/QuadTreeBenchmarks.cs
+++ b/src/DtronixCommonBenchmarks/Collections/Trees/QuadTreeBenchmarks.cs
@@ -6,7 +6,6 @@ using DtronixCommon.Collections.Trees;
 namespace DtronixCommonBenchmarks.Collections.Trees;
 
 [MemoryDiagnoser]
-[Config(typeof(FastConfig))]
 public class QuadTreeBenchmarks
 {
 

--- a/src/DtronixCommonBenchmarks/Collections/Trees/QuadTreeBenchmarks.cs
+++ b/src/DtronixCommonBenchmarks/Collections/Trees/QuadTreeBenchmarks.cs
@@ -27,8 +27,9 @@ public class QuadTreeBenchmarks
         var offsetY = 5;
         _quadTreeD = new DoubleQuadTree<Item>(10000, 10000, 8, 8, 200);
         _quadTreeF = new FloatQuadTree<Item>(10000, 10000, 8, 8, 200);
-
         _quadTreeFFull = new FloatQuadTree<Item>(10000, 10000, 8, 8, 1024);
+        _quadTreeDFull = new DoubleQuadTree<Item>(10000, 10000, 8, 8, 1024);
+
         for (int x = 0; x < 50; x++)
         {
             for (int y = 0; y < 50; y++)
@@ -40,8 +41,7 @@ public class QuadTreeBenchmarks
                     y + offsetY + offsetY * y, new Item());
             }
         }
-
-        _quadTreeDFull = new DoubleQuadTree<Item>(10000, 10000, 8, 8, 1024);
+        
         for (int x = 0; x < 50; x++)
         {
             for (int y = 0; y < 50; y++)
@@ -53,22 +53,15 @@ public class QuadTreeBenchmarks
                     y + offsetY + offsetY * y, new Item());
             }
         }
-
-    }
-
-    [Benchmark]
-    public void WalkFloat()
-    {
-        _quadTreeFFull.Walk(-5000, -5000, 5000, 5000, item => true);
     }
 
     [Benchmark]
     public void InsertFloat()
     {
-        
+
         var offsetX = 5;
         var offsetY = 5;
-        
+
         for (int x = 0; x < 10; x++)
         {
             for (int y = 0; y < 10; y++)
@@ -81,15 +74,15 @@ public class QuadTreeBenchmarks
             }
         }
         _quadTreeF.Clear();
-    }  
-    
+    }
+
     [Benchmark]
     public void InsertDouble()
     {
-        
+
         var offsetX = 5;
         var offsetY = 5;
-        
+
         for (int x = 0; x < 10; x++)
         {
             for (int y = 0; y < 10; y++)
@@ -103,13 +96,17 @@ public class QuadTreeBenchmarks
         }
         _quadTreeD.Clear();
     }
+    
 
+    [Benchmark]
+    public void WalkFloat()
+    {
+        _quadTreeFFull.Walk(-5000, -5000, 5000, 5000, item => true);
+    }
 
     [Benchmark]
     public void WalkDouble()
     {
         _quadTreeDFull.Walk(-5000, -5000, 5000, 5000, item => true);
     }
-
 }
-

--- a/src/DtronixCommonBenchmarks/DtronixCommonBenchmarks.csproj
+++ b/src/DtronixCommonBenchmarks/DtronixCommonBenchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -14,8 +14,8 @@
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DtronixCommon\DtronixCommon.csproj" />

--- a/src/DtronixCommonSamples/DtronixCommonSamples.csproj
+++ b/src/DtronixCommonSamples/DtronixCommonSamples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Incorporated performance enhancements from quad-tree-overlapping-struct

### Master performance
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.23590
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=8.0.100
  [Host]     : .NET Core 6.0.25 (CoreCLR 6.0.2523.51912, CoreFX 6.0.2523.51912), X64 RyuJIT
  DefaultJob : .NET Core 6.0.25 (CoreCLR 6.0.2523.51912, CoreFX 6.0.2523.51912), X64 RyuJIT


|       Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
|  InsertFloat | 49.72 μs | 0.141 μs | 0.125 μs | 1.0376 |     - |     - |    8736 B |
| InsertDouble | 52.24 μs | 0.136 μs | 0.121 μs | 1.0376 |     - |     - |    8736 B |
|    WalkFloat | 66.66 μs | 0.238 μs | 0.211 μs |      - |     - |     - |         - |
|   WalkDouble | 67.79 μs | 0.246 μs | 0.231 μs |      - |     - |     - |         - |

### PR performance
BenchmarkDotNet v0.13.10, Windows 11 (10.0.23590.1000)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

| Method       | Mean     | Error    | StdDev   | Gen0   | Allocated |
|------------- |---------:|---------:|---------:|-------:|----------:|
| InsertFloat  | 18.04 μs | 0.025 μs | 0.020 μs | 0.8240 |    7008 B |
| InsertDouble | 18.29 μs | 0.040 μs | 0.036 μs | 0.8240 |    7008 B |
| WalkFloat    | 18.29 μs | 0.034 μs | 0.028 μs |      - |         - |
| WalkDouble   | 18.46 μs | 0.043 μs | 0.036 μs |      - |         - |

Walking is ~3.6x faster and insertion is 2.6x faster!
Part of this is due to PGO being enabled as the PGO portion of this can be seen in the warmup portion of the benchmarks.
```
WorkloadPilot    1: 16 op, 394300.00 ns, 24.6438 us/op
WorkloadPilot    2: 32 op, 768500.00 ns, 24.0156 us/op
WorkloadPilot    3: 64 op, 1521200.00 ns, 23.7688 us/op
WorkloadPilot    4: 128 op, 3060000.00 ns, 23.9062 us/op
WorkloadPilot    5: 256 op, 5930000.00 ns, 23.1641 us/op
WorkloadPilot    6: 512 op, 11752300.00 ns, 22.9537 us/op
WorkloadPilot    7: 1024 op, 23819700.00 ns, 23.2614 us/op
WorkloadPilot    8: 2048 op, 46267500.00 ns, 22.5916 us/op
WorkloadPilot    9: 4096 op, 83309500.00 ns, 20.3392 us/op
WorkloadPilot   10: 8192 op, 151236600.00 ns, 18.4615 us/op
WorkloadPilot   11: 16384 op, 302332400.00 ns, 18.4529 us/op
WorkloadPilot   12: 32768 op, 602806900.00 ns, 18.3962 us/op
```